### PR TITLE
[TD-3983] <enhence>: support to use taos.cfg in go connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ sql.Open(DRIVER_NAME string, dataSourceName string) *DB
 
 该API用来打开DB，返回一个类型为`\*DB`的对象，一般情况下，`DRIVER_NAME`设置为字符串`taosSql`, `dataSourceName`设置为字符串`user:password@/tcp(host:port)/dbname`，如果客户想要用多个goroutine并发访问TDengine, 那么需要在各个goroutine中分别创建一个`sql.Open`对象并用之访问TDengine。
 
+建议使用 `user:password@/tcp(:)/dbname` 或 `user:password@/cfg/dbname` 使用 `/etc/taos/taos.cfg` 中的配置来支持客户端连接的高可用。
+
 注意： 该API成功创建的时候，并没有做权限等检查，只有在真正执行Query或者Exec的时候才能真正的去创建连接，并同时检查user/password/host/port是不是合法。 另外，由于整个驱动程序大部分实现都下沉到taosSql所依赖的libtaos中。所以，sql.Open本身特别轻量。
 
 ```go

--- a/examples/uint.go
+++ b/examples/uint.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/taosdata/driver-go/taosSql"
@@ -24,7 +23,7 @@ const (
 
 type config struct {
 	hostName   string
-	serverPort int
+	serverPort string
 	user       string
 	password   string
 	dbName     string
@@ -35,8 +34,8 @@ var taosDriverName = "taosSql"
 var url string
 
 func init() {
-	flag.StringVar(&configPara.hostName, "h", "127.0.0.1", "The host to connect to TDengine server.")
-	flag.IntVar(&configPara.serverPort, "p", 6030, "The TCP/IP port number to use for the connection to TDengine server.")
+	flag.StringVar(&configPara.hostName, "h", "", "The host to connect to TDengine server.")
+	flag.StringVar(&configPara.serverPort, "p", "", "The TCP/IP port number to use for the connection to TDengine server.")
 	flag.StringVar(&configPara.user, "u", "root", "The TDengine user name to use when connecting to the server.")
 	flag.StringVar(&configPara.password, "P", "taosdata", "The password to use when connecting to the server.")
 	flag.StringVar(&configPara.dbName, "d", "taosuint", "Destination database.")
@@ -56,7 +55,7 @@ func printAllArgs() {
 func main() {
 	printAllArgs()
 
-	url = "root:taosdata@/tcp(" + configPara.hostName + ":" + strconv.Itoa(configPara.serverPort) + ")/"
+	url = "root:taosdata@/tcp(" + configPara.hostName + ":" + configPara.serverPort + ")/"
 
 	test(configPara.dbName)
 }

--- a/taosSql/dsn.go
+++ b/taosSql/dsn.go
@@ -98,16 +98,18 @@ func parseDSN(dsn string) (cfg *config, err error) {
 							if strings.ContainsRune(dsn[k+1:i], ')') {
 								return nil, errInvalidDSNUnescaped
 							}
-							return nil, errInvalidDSNAddr
+							//return nil, errInvalidDSNAddr
 						}
 						strs := strings.Split(dsn[k+1:i-1], ":")
 						if len(strs) == 1 {
 							return nil, errInvalidDSNAddr
 						}
-						cfg.addr = strs[0]
-						cfg.port, err = strconv.Atoi(strs[1])
-						if err != nil {
-							return nil, errInvalidDSNPort
+						if len(strs[0]) != 0 {
+							cfg.addr = strs[0]
+							cfg.port, err = strconv.Atoi(strs[1])
+							if err != nil {
+								return nil, errInvalidDSNPort
+							}
 						}
 						break
 					}


### PR DESCRIPTION
User could use `user:pass@/tcp(:)/db` to use taos.cfg settings.