### PR TITLE
fix(schemaless client): check for returned errors before using the WebSocket client that may lead to panic in the code.

### DIFF
--- a/ws/schemaless/schemaless.go
+++ b/ws/schemaless/schemaless.go
@@ -48,10 +48,10 @@ func NewSchemaless(config *Config) (*Schemaless, error) {
 	dialer := common.DefaultDialer
 	dialer.EnableCompression = config.enableCompression
 	ws, _, err := dialer.Dial(wsUrl.String(), nil)
-	ws.EnableWriteCompression(config.enableCompression)
 	if err != nil {
 		return nil, fmt.Errorf("dial ws error: %s", err)
 	}
+	ws.EnableWriteCompression(config.enableCompression)
 
 	s := Schemaless{
 		client:       client.NewClient(ws, config.chanLength),


### PR DESCRIPTION
Fixes https://github.com/taosdata/driver-go/issues/279