### PR TITLE
fix: handle empty strings and byte slices in stmt2

### DIFF
--- a/wrapper/stmt2.go
+++ b/wrapper/stmt2.go
@@ -443,10 +443,14 @@ func generateTaosStmt2BindsInsert(multiBind [][]driver.Value, fieldTypes []*stmt
 				if rowData != nil {
 					switch value := rowData.(type) {
 					case string:
-						x := ToUnsafeBytes(value)
-						C.memcpy(unsafe.Pointer(uintptr(p)+uintptr(colOffset[i])), unsafe.Pointer(&x[0]), C.size_t(len(value)))
+						if len(value) > 0 {
+							x := ToUnsafeBytes(value)
+							C.memcpy(unsafe.Pointer(uintptr(p)+uintptr(colOffset[i])), unsafe.Pointer(&x[0]), C.size_t(len(value)))
+						}
 					case []byte:
-						C.memcpy(unsafe.Pointer(uintptr(p)+uintptr(colOffset[i])), unsafe.Pointer(&value[0]), C.size_t(len(value)))
+						if len(value) > 0 {
+							C.memcpy(unsafe.Pointer(uintptr(p)+uintptr(colOffset[i])), unsafe.Pointer(&value[0]), C.size_t(len(value)))
+						}
 					default:
 						return nil, needFreePointer, fmt.Errorf("data type error, expect string or []byte, but got %T, value: %v", rowData, value)
 					}
@@ -599,7 +603,9 @@ func generateTaosStmt2BindsQuery(multiBind [][]driver.Value) (unsafe.Pointer, []
 			p = unsafe.Pointer(C.malloc(C.size_t(C.uint(valueLength))))
 			needFreePointer = append(needFreePointer, p)
 			bind.buffer_type = C.TSDB_DATA_TYPE_BINARY
-			C.memcpy(p, unsafe.Pointer(&rowData[0]), C.size_t(valueLength))
+			if valueLength > 0 {
+				C.memcpy(p, unsafe.Pointer(&rowData[0]), C.size_t(valueLength))
+			}
 			lengthList = unsafe.Pointer(C.calloc(C.size_t(C.uint(1)), C.size_t(C.uint(4))))
 			needFreePointer = append(needFreePointer, lengthList)
 			*(*C.int32_t)(lengthList) = C.int32_t(valueLength)
@@ -609,7 +615,9 @@ func generateTaosStmt2BindsQuery(multiBind [][]driver.Value) (unsafe.Pointer, []
 			needFreePointer = append(needFreePointer, p)
 			bind.buffer_type = C.TSDB_DATA_TYPE_BINARY
 			x := ToUnsafeBytes(rowData)
-			C.memcpy(p, unsafe.Pointer(&x[0]), C.size_t(valueLength))
+			if valueLength > 0 {
+				C.memcpy(p, unsafe.Pointer(&x[0]), C.size_t(valueLength))
+			}
 			lengthList = unsafe.Pointer(C.calloc(C.size_t(C.uint(1)), C.size_t(C.uint(4))))
 			needFreePointer = append(needFreePointer, lengthList)
 			*(*C.int32_t)(lengthList) = C.int32_t(valueLength)
@@ -620,7 +628,9 @@ func generateTaosStmt2BindsQuery(multiBind [][]driver.Value) (unsafe.Pointer, []
 			p = unsafe.Pointer(C.malloc(C.size_t(C.uint(valueLength))))
 			needFreePointer = append(needFreePointer, p)
 			bind.buffer_type = C.TSDB_DATA_TYPE_BINARY
-			C.memcpy(p, unsafe.Pointer(&value[0]), C.size_t(valueLength))
+			if valueLength > 0 {
+				C.memcpy(p, unsafe.Pointer(&value[0]), C.size_t(valueLength))
+			}
 			lengthList = unsafe.Pointer(C.calloc(C.size_t(C.uint(1)), C.size_t(C.uint(4))))
 			needFreePointer = append(needFreePointer, lengthList)
 			*(*C.int32_t)(lengthList) = C.int32_t(valueLength)

--- a/wrapper/stmt2_test.go
+++ b/wrapper/stmt2_test.go
@@ -66,6 +66,7 @@ func TestStmt2BindData(t *testing.T) {
 	now := time.Now().Round(time.Millisecond)
 	next1S := now.Add(time.Second)
 	next2S := now.Add(2 * time.Second)
+	next3S := now.Add(3 * time.Second)
 
 	tests := []struct {
 		name        string
@@ -783,7 +784,45 @@ func TestStmt2BindData(t *testing.T) {
 			},
 		},
 		{
-			name:   "binary null 3 cols",
+			name:   "binary empty string",
+			tbType: "ts timestamp, v binary(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						"",
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, ""},
+			},
+		},
+		{
+			name:   "binary empty bytes",
+			tbType: "ts timestamp, v binary(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						[]byte{},
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, ""},
+			},
+		},
+		{
+			name:   "binary null 4 cols",
 			tbType: "ts timestamp, v binary(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -792,11 +831,13 @@ func TestStmt2BindData(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						[]byte("yes"),
 						nil,
 						[]byte("中文"),
+						[]byte(""),
 					},
 				},
 			}},
@@ -805,6 +846,7 @@ func TestStmt2BindData(t *testing.T) {
 				{now, "yes"},
 				{next1S, nil},
 				{next2S, "中文"},
+				{next3S, ""},
 			},
 		},
 
@@ -848,7 +890,47 @@ func TestStmt2BindData(t *testing.T) {
 		},
 
 		{
-			name:   "varbinary null 3 cols",
+			name:   "varbinary empty string",
+			tbType: "ts timestamp, v varbinary(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						"",
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, []byte{}},
+			},
+		},
+
+		{
+			name:   "varbinary empty bytes",
+			tbType: "ts timestamp, v varbinary(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						[]byte{},
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, []byte{}},
+			},
+		},
+
+		{
+			name:   "varbinary null 4 cols",
 			tbType: "ts timestamp, v varbinary(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -857,11 +939,13 @@ func TestStmt2BindData(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						[]byte("yes"),
 						nil,
 						[]byte("中文"),
+						[]byte{},
 					},
 				},
 			}},
@@ -870,6 +954,7 @@ func TestStmt2BindData(t *testing.T) {
 				{now, []byte("yes")},
 				{next1S, nil},
 				{next2S, []byte("中文")},
+				{next3S, []byte("")},
 			},
 		},
 
@@ -976,7 +1061,45 @@ func TestStmt2BindData(t *testing.T) {
 			},
 		},
 		{
-			name:   "nchar null 3 cols",
+			name:   "nchar empty string",
+			tbType: "ts timestamp, v nchar(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						"",
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, ""},
+			},
+		},
+		{
+			name:   "nchar empty bytes",
+			tbType: "ts timestamp, v nchar(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						[]byte{},
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, ""},
+			},
+		},
+		{
+			name:   "nchar null 4 cols",
 			tbType: "ts timestamp, v nchar(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -985,11 +1108,13 @@ func TestStmt2BindData(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						[]byte("yes"),
 						nil,
 						[]byte("中文"),
+						[]byte(""),
 					},
 				},
 			}},
@@ -998,6 +1123,7 @@ func TestStmt2BindData(t *testing.T) {
 				{now, "yes"},
 				{next1S, nil},
 				{next2S, "中文"},
+				{next3S, ""},
 			},
 		},
 
@@ -1022,7 +1148,7 @@ func TestStmt2BindData(t *testing.T) {
 		},
 
 		{
-			name:   "nchar bind string null 3 cols",
+			name:   "nchar bind string null 4 cols",
 			tbType: "ts timestamp, v nchar(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -1031,11 +1157,13 @@ func TestStmt2BindData(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						"yes",
 						nil,
 						"中文",
+						"",
 					},
 				},
 			}},
@@ -1044,6 +1172,7 @@ func TestStmt2BindData(t *testing.T) {
 				{now, "yes"},
 				{next1S, nil},
 				{next2S, "中文"},
+				{next3S, ""},
 			},
 		},
 
@@ -1068,7 +1197,7 @@ func TestStmt2BindData(t *testing.T) {
 		},
 
 		{
-			name:   "binary bind string null 3 cols",
+			name:   "binary bind string null 4 cols",
 			tbType: "ts timestamp, v binary(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -1077,11 +1206,13 @@ func TestStmt2BindData(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						"yes",
 						nil,
 						"中文",
+						"",
 					},
 				},
 			}},
@@ -1090,6 +1221,7 @@ func TestStmt2BindData(t *testing.T) {
 				{now, "yes"},
 				{next1S, nil},
 				{next2S, "中文"},
+				{next3S, ""},
 			},
 		},
 
@@ -1114,7 +1246,7 @@ func TestStmt2BindData(t *testing.T) {
 		},
 
 		{
-			name:   "varbinary bind string null 3 cols",
+			name:   "varbinary bind string null 4 cols",
 			tbType: "ts timestamp, v varbinary(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -1123,11 +1255,13 @@ func TestStmt2BindData(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						"yes",
 						nil,
 						"中文",
+						"",
 					},
 				},
 			}},
@@ -1136,6 +1270,7 @@ func TestStmt2BindData(t *testing.T) {
 				{now, []byte("yes")},
 				{next1S, nil},
 				{next2S, []byte("中文")},
+				{next3S, []byte("")},
 			},
 		},
 
@@ -1271,6 +1406,7 @@ func TestStmt2BindBinary(t *testing.T) {
 	now := time.Now().Round(time.Millisecond)
 	next1S := now.Add(time.Second)
 	next2S := now.Add(2 * time.Second)
+	next3S := now.Add(3 * time.Second)
 
 	tests := []struct {
 		name        string
@@ -1336,10 +1472,20 @@ func TestStmt2BindBinary(t *testing.T) {
 			tbType: "ts timestamp, v bool",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
-				Cols: [][]driver.Value{{now}, {bool(true)}},
+				Cols: [][]driver.Value{{now}, {true}},
 			}},
 
 			expectValue: [][]driver.Value{{now, true}},
+		},
+		{
+			name:   "bool false",
+			tbType: "ts timestamp, v bool",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{{now}, {false}},
+			}},
+
+			expectValue: [][]driver.Value{{now, false}},
 		},
 		{
 			name:   "bool null",
@@ -1978,7 +2124,45 @@ func TestStmt2BindBinary(t *testing.T) {
 			},
 		},
 		{
-			name:   "binary null 3 cols",
+			name:   "binary empty string",
+			tbType: "ts timestamp, v binary(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						"",
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, ""},
+			},
+		},
+		{
+			name:   "binary empty bytes",
+			tbType: "ts timestamp, v binary(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						[]byte{},
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, ""},
+			},
+		},
+		{
+			name:   "binary null 4 cols",
 			tbType: "ts timestamp, v binary(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -1987,11 +2171,13 @@ func TestStmt2BindBinary(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						[]byte("yes"),
 						nil,
 						[]byte("中文"),
+						[]byte(""),
 					},
 				},
 			}},
@@ -2000,6 +2186,7 @@ func TestStmt2BindBinary(t *testing.T) {
 				{now, "yes"},
 				{next1S, nil},
 				{next2S, "中文"},
+				{next3S, ""},
 			},
 		},
 
@@ -2043,7 +2230,47 @@ func TestStmt2BindBinary(t *testing.T) {
 		},
 
 		{
-			name:   "varbinary null 3 cols",
+			name:   "varbinary empty string",
+			tbType: "ts timestamp, v varbinary(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						"",
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, []byte{}},
+			},
+		},
+
+		{
+			name:   "varbinary empty bytes",
+			tbType: "ts timestamp, v varbinary(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						[]byte{},
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, []byte{}},
+			},
+		},
+
+		{
+			name:   "varbinary null 4 cols",
 			tbType: "ts timestamp, v varbinary(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -2052,11 +2279,13 @@ func TestStmt2BindBinary(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						[]byte("yes"),
 						nil,
 						[]byte("中文"),
+						[]byte{},
 					},
 				},
 			}},
@@ -2065,6 +2294,7 @@ func TestStmt2BindBinary(t *testing.T) {
 				{now, []byte("yes")},
 				{next1S, nil},
 				{next2S, []byte("中文")},
+				{next3S, []byte("")},
 			},
 		},
 
@@ -2171,7 +2401,45 @@ func TestStmt2BindBinary(t *testing.T) {
 			},
 		},
 		{
-			name:   "nchar null 3 cols",
+			name:   "nchar empty string",
+			tbType: "ts timestamp, v nchar(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						"",
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, ""},
+			},
+		},
+		{
+			name:   "nchar empty bytes",
+			tbType: "ts timestamp, v nchar(20)",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						[]byte{},
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, ""},
+			},
+		},
+		{
+			name:   "nchar null 4 cols",
 			tbType: "ts timestamp, v nchar(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -2180,11 +2448,13 @@ func TestStmt2BindBinary(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						[]byte("yes"),
 						nil,
 						[]byte("中文"),
+						[]byte(""),
 					},
 				},
 			}},
@@ -2193,6 +2463,7 @@ func TestStmt2BindBinary(t *testing.T) {
 				{now, "yes"},
 				{next1S, nil},
 				{next2S, "中文"},
+				{next3S, ""},
 			},
 		},
 
@@ -2217,7 +2488,7 @@ func TestStmt2BindBinary(t *testing.T) {
 		},
 
 		{
-			name:   "nchar bind string null 3 cols",
+			name:   "nchar bind string null 4 cols",
 			tbType: "ts timestamp, v nchar(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -2226,11 +2497,13 @@ func TestStmt2BindBinary(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						"yes",
 						nil,
 						"中文",
+						"",
 					},
 				},
 			}},
@@ -2239,6 +2512,7 @@ func TestStmt2BindBinary(t *testing.T) {
 				{now, "yes"},
 				{next1S, nil},
 				{next2S, "中文"},
+				{next3S, ""},
 			},
 		},
 
@@ -2263,7 +2537,7 @@ func TestStmt2BindBinary(t *testing.T) {
 		},
 
 		{
-			name:   "binary bind string null 3 cols",
+			name:   "binary bind string null 4 cols",
 			tbType: "ts timestamp, v binary(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -2272,11 +2546,13 @@ func TestStmt2BindBinary(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						"yes",
 						nil,
 						"中文",
+						"",
 					},
 				},
 			}},
@@ -2285,6 +2561,7 @@ func TestStmt2BindBinary(t *testing.T) {
 				{now, "yes"},
 				{next1S, nil},
 				{next2S, "中文"},
+				{next3S, ""},
 			},
 		},
 
@@ -2309,7 +2586,7 @@ func TestStmt2BindBinary(t *testing.T) {
 		},
 
 		{
-			name:   "varbinary bind string null 3 cols",
+			name:   "varbinary bind string null 4 cols",
 			tbType: "ts timestamp, v varbinary(20)",
 			pos:    "?, ?",
 			params: []*stmt.TaosStmt2BindData{{
@@ -2318,11 +2595,13 @@ func TestStmt2BindBinary(t *testing.T) {
 						now,
 						next1S,
 						next2S,
+						next3S,
 					},
 					{
 						"yes",
 						nil,
 						"中文",
+						"",
 					},
 				},
 			}},
@@ -2331,6 +2610,27 @@ func TestStmt2BindBinary(t *testing.T) {
 				{now, []byte("yes")},
 				{next1S, nil},
 				{next2S, []byte("中文")},
+				{next3S, []byte("")},
+			},
+		},
+
+		{
+			name:   "timestamp",
+			tbType: "ts timestamp, v timestamp",
+			pos:    "?, ?",
+			params: []*stmt.TaosStmt2BindData{{
+				Cols: [][]driver.Value{
+					{
+						now,
+					},
+					{
+						now,
+					},
+				},
+			}},
+
+			expectValue: [][]driver.Value{
+				{now, now},
 			},
 		},
 	}
@@ -3032,81 +3332,97 @@ func TestStmt2AllType(t *testing.T) {
 				now,
 				now.Add(time.Second),
 				now.Add(time.Second * 2),
+				now.Add(time.Second * 3),
 			},
 			{
 				true,
 				nil,
 				false,
+				true,
 			},
 			{
 				int8(11),
 				nil,
 				int8(12),
+				int8(13),
 			},
 			{
 				int16(11),
 				nil,
 				int16(12),
+				int16(13),
 			},
 			{
 				int32(11),
 				nil,
 				int32(12),
+				int32(13),
 			},
 			{
 				int64(11),
 				nil,
 				int64(12),
+				int64(13),
 			},
 			{
 				uint8(11),
 				nil,
 				uint8(12),
+				uint8(13),
 			},
 			{
 				uint16(11),
 				nil,
 				uint16(12),
+				uint16(13),
 			},
 			{
 				uint32(11),
 				nil,
 				uint32(12),
+				uint32(13),
 			},
 			{
 				uint64(11),
 				nil,
 				uint64(12),
+				uint64(13),
 			},
 			{
 				float32(11.2),
 				nil,
 				float32(12.2),
+				float32(13.2),
 			},
 			{
 				float64(11.2),
 				nil,
 				float64(12.2),
+				float64(13.2),
 			},
 			{
 				[]byte("binary1"),
 				nil,
 				[]byte("binary2"),
+				[]byte(""),
 			},
 			{
 				[]byte("varbinary1"),
 				nil,
 				[]byte("varbinary2"),
+				[]byte(""),
 			},
 			{
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
 				nil,
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
+				nil,
 			},
 			{
 				"nchar1",
 				nil,
 				"nchar2",
+				"",
 			},
 		},
 	}}
@@ -3131,7 +3447,7 @@ func TestStmt2AllType(t *testing.T) {
 		return
 	}
 	t.Log(r.affected)
-
+	assert.Equal(t, 4, int(r.affected))
 	code = TaosStmt2Close(insertStmt)
 	if code != 0 {
 		errStr := TaosStmt2Error(insertStmt)
@@ -3295,81 +3611,97 @@ func TestStmt2AllTypeBytes(t *testing.T) {
 				now,
 				now.Add(time.Second),
 				now.Add(time.Second * 2),
+				now.Add(time.Second * 3),
 			},
 			{
 				true,
 				nil,
 				false,
+				true,
 			},
 			{
 				int8(11),
 				nil,
 				int8(12),
+				int8(13),
 			},
 			{
 				int16(11),
 				nil,
 				int16(12),
+				int16(13),
 			},
 			{
 				int32(11),
 				nil,
 				int32(12),
+				int32(13),
 			},
 			{
 				int64(11),
 				nil,
 				int64(12),
+				int64(13),
 			},
 			{
 				uint8(11),
 				nil,
 				uint8(12),
+				uint8(13),
 			},
 			{
 				uint16(11),
 				nil,
 				uint16(12),
+				uint16(13),
 			},
 			{
 				uint32(11),
 				nil,
 				uint32(12),
+				uint32(13),
 			},
 			{
 				uint64(11),
 				nil,
 				uint64(12),
+				uint64(13),
 			},
 			{
 				float32(11.2),
 				nil,
 				float32(12.2),
+				float32(13.2),
 			},
 			{
 				float64(11.2),
 				nil,
 				float64(12.2),
+				float64(13.2),
 			},
 			{
 				[]byte("binary1"),
 				nil,
 				[]byte("binary2"),
+				[]byte(""),
 			},
 			{
 				[]byte("varbinary1"),
 				nil,
 				[]byte("varbinary2"),
+				[]byte(""),
 			},
 			{
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
 				nil,
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
+				nil,
 			},
 			{
 				"nchar1",
 				nil,
 				"nchar2",
+				"",
 			},
 		},
 	}}
@@ -3398,7 +3730,7 @@ func TestStmt2AllTypeBytes(t *testing.T) {
 		return
 	}
 	t.Log(r.affected)
-
+	assert.Equal(t, 4, int(r.affected))
 	code = TaosStmt2Close(insertStmt)
 	if code != 0 {
 		errStr := TaosStmt2Error(insertStmt)
@@ -3897,81 +4229,97 @@ func TestStmt2QueryAllType(t *testing.T) {
 				now,
 				now.Add(time.Second),
 				now.Add(time.Second * 2),
+				now.Add(time.Second * 3),
 			},
 			{
 				true,
 				nil,
 				false,
+				true,
 			},
 			{
 				int8(11),
 				nil,
 				int8(12),
+				int8(13),
 			},
 			{
 				int16(11),
 				nil,
 				int16(12),
+				int16(13),
 			},
 			{
 				int32(11),
 				nil,
 				int32(12),
+				int32(13),
 			},
 			{
 				int64(11),
 				nil,
 				int64(12),
+				int64(13),
 			},
 			{
 				uint8(11),
 				nil,
 				uint8(12),
+				uint8(13),
 			},
 			{
 				uint16(11),
 				nil,
 				uint16(12),
+				uint16(13),
 			},
 			{
 				uint32(11),
 				nil,
 				uint32(12),
+				uint32(13),
 			},
 			{
 				uint64(11),
 				nil,
 				uint64(12),
+				uint64(13),
 			},
 			{
 				float32(11.2),
 				nil,
 				float32(12.2),
+				float32(13.2),
 			},
 			{
 				float64(11.2),
 				nil,
 				float64(12.2),
+				float64(13.2),
 			},
 			{
 				[]byte("binary1"),
 				nil,
 				[]byte("binary2"),
+				[]byte(""),
 			},
 			{
 				[]byte("varbinary1"),
 				nil,
 				[]byte("varbinary2"),
+				[]byte(""),
 			},
 			{
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
 				nil,
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
+				nil,
 			},
 			{
 				"nchar1",
 				nil,
 				"nchar2",
+				"",
 			},
 		},
 	}}
@@ -4010,7 +4358,7 @@ func TestStmt2QueryAllType(t *testing.T) {
 		return
 	}
 	t.Log(r.affected)
-	assert.Equal(t, 3, r.affected)
+	assert.Equal(t, 4, r.affected)
 	code = TaosStmt2Prepare(stmt2, "select * from t where ts =? and v1 = ? and v2 = ? and v3 = ? and v4 = ? and v5 = ? and v6 = ? and v7 = ? and v8 = ? and v9 = ? and v10 = ? and v11 = ? and v12 = ? and v13 = ? and v14 = ? and v15 = ? ")
 	if code != 0 {
 		errStr := TaosStmt2Error(stmt2)
@@ -4181,81 +4529,97 @@ func TestStmt2QueryAllTypeBytes(t *testing.T) {
 				now,
 				now.Add(time.Second),
 				now.Add(time.Second * 2),
+				now.Add(time.Second * 3),
 			},
 			{
 				true,
 				nil,
 				false,
+				true,
 			},
 			{
 				int8(11),
 				nil,
 				int8(12),
+				int8(13),
 			},
 			{
 				int16(11),
 				nil,
 				int16(12),
+				int16(13),
 			},
 			{
 				int32(11),
 				nil,
 				int32(12),
+				int32(13),
 			},
 			{
 				int64(11),
 				nil,
 				int64(12),
+				int64(13),
 			},
 			{
 				uint8(11),
 				nil,
 				uint8(12),
+				uint8(13),
 			},
 			{
 				uint16(11),
 				nil,
 				uint16(12),
+				uint16(13),
 			},
 			{
 				uint32(11),
 				nil,
 				uint32(12),
+				uint32(13),
 			},
 			{
 				uint64(11),
 				nil,
 				uint64(12),
+				uint64(13),
 			},
 			{
 				float32(11.2),
 				nil,
 				float32(12.2),
+				float32(13.2),
 			},
 			{
 				float64(11.2),
 				nil,
 				float64(12.2),
+				float64(13.2),
 			},
 			{
 				[]byte("binary1"),
 				nil,
 				[]byte("binary2"),
+				[]byte(""),
 			},
 			{
 				[]byte("varbinary1"),
 				nil,
 				[]byte("varbinary2"),
+				[]byte(""),
 			},
 			{
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
 				nil,
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
+				nil,
 			},
 			{
 				"nchar1",
 				nil,
 				"nchar2",
+				"",
 			},
 		},
 	}}
@@ -4299,7 +4663,7 @@ func TestStmt2QueryAllTypeBytes(t *testing.T) {
 		return
 	}
 	t.Log(r.affected)
-	assert.Equal(t, 3, r.affected)
+	assert.Equal(t, 4, r.affected)
 	code = TaosStmt2Prepare(stmt2, "select * from t where ts =? and v1 = ? and v2 = ? and v3 = ? and v4 = ? and v5 = ? and v6 = ? and v7 = ? and v8 = ? and v9 = ? and v10 = ? and v11 = ? and v12 = ? and v13 = ? and v14 = ? and v15 = ? ")
 	if code != 0 {
 		errStr := TaosStmt2Error(stmt2)
@@ -5862,7 +6226,7 @@ func TestStmt2BindTbnameAsValue(t *testing.T) {
 	}
 	defer TaosClose(conn)
 	defer func() {
-		err = exec(conn, "drop database if exists test_stmt2_bind_tbname_as_value")
+		//err = exec(conn, "drop database if exists test_stmt2_bind_tbname_as_value")
 		if err != nil {
 			t.Error(err)
 			return
@@ -6198,81 +6562,97 @@ func TestStmt2BindTbnameAsValue(t *testing.T) {
 				now,
 				now.Add(time.Second),
 				now.Add(time.Second * 2),
+				now.Add(time.Second * 3),
 			},
 			{
 				true,
 				nil,
 				false,
+				true,
 			},
 			{
 				int8(11),
 				nil,
 				int8(12),
+				int8(13),
 			},
 			{
 				int16(11),
 				nil,
 				int16(12),
+				int16(13),
 			},
 			{
 				int32(11),
 				nil,
 				int32(12),
+				int32(13),
 			},
 			{
 				int64(11),
 				nil,
 				int64(12),
+				int64(13),
 			},
 			{
 				uint8(11),
 				nil,
 				uint8(12),
+				uint8(13),
 			},
 			{
 				uint16(11),
 				nil,
 				uint16(12),
+				uint16(13),
 			},
 			{
 				uint32(11),
 				nil,
 				uint32(12),
+				uint32(13),
 			},
 			{
 				uint64(11),
 				nil,
 				uint64(12),
+				uint64(13),
 			},
 			{
 				float32(11.2),
 				nil,
 				float32(12.2),
+				float32(13.2),
 			},
 			{
 				float64(11.2),
 				nil,
 				float64(12.2),
+				float64(13.2),
 			},
 			{
 				[]byte("binary1"),
 				nil,
 				[]byte("binary2"),
+				[]byte(""),
 			},
 			{
 				[]byte("varbinary1"),
 				nil,
 				[]byte("varbinary2"),
+				[]byte(""),
 			},
 			{
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
 				nil,
 				[]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40},
+				nil,
 			},
 			{
 				"nchar1",
 				nil,
 				"nchar2",
+				"",
 			},
 		},
 	}}
@@ -6297,7 +6677,7 @@ func TestStmt2BindTbnameAsValue(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	assert.Equal(t, 3, r.affected)
+	assert.Equal(t, 4, r.affected)
 
 	code = TaosStmt2Close(insertStmt)
 	if code != 0 {


### PR DESCRIPTION
# Description

fix: handle empty strings and byte slices in stmt2

Jira: https://jira.taosdata.com:18080/browse/TD-

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
