### PR TITLE
fix: fix nil return to Send's caller after sendChan closes, resulting…

### DIFF
--- a/ws/client/conn.go
+++ b/ws/client/conn.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	jsoniter "github.com/json-iterator/go"
+
 	"github.com/taosdata/driver-go/v3/common"
 	errors2 "github.com/taosdata/driver-go/v3/errors"
 )
@@ -76,7 +77,7 @@ type Client struct {
 	TextMessageHandler   func(message []byte)
 	BinaryMessageHandler func(message []byte)
 	ErrorHandler         func(err error)
-	//SendMessageHandler   func(envelope *Envelope)
+	// SendMessageHandler   func(envelope *Envelope)
 	once           sync.Once
 	errHandlerOnce sync.Once
 }
@@ -168,11 +169,10 @@ func (c *Client) WritePump() {
 	}
 }
 
-func (c *Client) Send(envelope *Envelope) error {
+func (c *Client) Send(envelope *Envelope) (err error) {
 	if !c.IsRunning() {
 		return ClosedError
 	}
-	var err error
 	defer func() {
 		// maybe closed
 		if recover() != nil {
@@ -181,7 +181,7 @@ func (c *Client) Send(envelope *Envelope) error {
 		}
 	}()
 	c.sendChan <- envelope
-	return err
+	return
 }
 
 func (c *Client) GetEnvelope() *Envelope {

--- a/ws/client/conn_test.go
+++ b/ws/client/conn_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+
 	taosErrors "github.com/taosdata/driver-go/v3/errors"
 )
 
@@ -100,6 +101,11 @@ func TestClient(t *testing.T) {
 	case <-timeout.C:
 		t.Error("timeout")
 	}
+	close(c.sendChan)
+	env = c.GetEnvelope()
+	err = c.Send(env)
+	assert.Equal(t, ClosedError, err)
+	c.sendChan = make(chan *Envelope, 1)
 }
 
 func TestHandleResponseError(t *testing.T) {


### PR DESCRIPTION
… in caller deadlocks

# Description

<!-- Please briefly describe the code changes in this pull request. -->

After c.sendChan is closed, c.sendChan <- envelope raises panic, and after recover(), although err = ClosedError assigns a value to err, the error received by the caller is nil, causing the caller to block forever waiting for err = <-envelope. ErrorChan

```go
func (c *Client) Send(envelope *Envelope) (err error) {
	if !c.IsRunning() {
		return ClosedError
	}
	defer func() {
		// maybe closed
		if recover() != nil {
			err = ClosedError
			return // Incorrectly returned nil
		}
	}()
	c.sendChan <- envelope
	return
}
```

```go
func (c *Consumer) sendText(reqID uint64, envelope *client.Envelope) ([]byte, error) {
	......
	err := c.client.Send(envelope)
	if err != nil {
		c.listLock.Lock()
		c.sendChanList.Remove(element)
		c.listLock.Unlock()
		return nil, err
	}
	err = <-envelope.ErrorChan // Wait forever for Error Chan to return
	......
}
```

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
