### PR TITLE
feat: add configurable read and write buffer sizes for websocket conn…

### DIFF
--- a/taosWS/connection.go
+++ b/taosWS/connection.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	jsoniter "github.com/json-iterator/go"
+
 	"github.com/taosdata/driver-go/v3/common"
 	stmtCommon "github.com/taosdata/driver-go/v3/common/stmt"
 	"github.com/taosdata/driver-go/v3/common/tdversion"
@@ -86,6 +87,12 @@ func newTaosConn(cfg *Config) (*taosConn, error) {
 	}
 	endpoint := endpointUrl.String()
 	dialer := common.DefaultDialer
+	if cfg.ReadBufferSize > 0 {
+		dialer.ReadBufferSize = cfg.ReadBufferSize
+	}
+	if cfg.WriteBufferSize > 0 {
+		dialer.WriteBufferSize = cfg.WriteBufferSize
+	}
 	dialer.EnableCompression = cfg.EnableCompression
 	ws, _, err := dialer.Dial(endpoint, nil)
 	if err != nil {

--- a/taosWS/dsn.go
+++ b/taosWS/dsn.go
@@ -180,15 +180,15 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			cfg.BearerToken = value
 		case "totpCode":
 			cfg.TotpCode = value
-		case "readBufferSize":
-			cfg.ReadBufferSize, err = strconv.Atoi(value)
+		case "readBufferSize", "writeBufferSize":
+			val, err := strconv.Atoi(value)
 			if err != nil {
-				return &errors.TaosError{Code: 0xffff, ErrStr: "invalid readBufferSize value: " + value}
+				return &errors.TaosError{Code: 0xffff, ErrStr: "invalid " + param[0] + " value: " + value}
 			}
-		case "writeBufferSize":
-			cfg.WriteBufferSize, err = strconv.Atoi(value)
-			if err != nil {
-				return &errors.TaosError{Code: 0xffff, ErrStr: "invalid writeBufferSize value: " + value}
+			if param[0] == "readBufferSize" {
+				cfg.ReadBufferSize = val
+			} else {
+				cfg.WriteBufferSize = val
 			}
 		default:
 			// lazy init

--- a/taosWS/dsn.go
+++ b/taosWS/dsn.go
@@ -37,6 +37,8 @@ type Config struct {
 	Timezone          *time.Location    // Timezone for connection, e.g., "Asia%2FShanghai" or "UTC"
 	BearerToken       string            // BearerToken for TSDB auth
 	TotpCode          string            // TOTP code for TSDB TOTP auth
+	ReadBufferSize    int               // Read buffer size
+	WriteBufferSize   int               // Write buffer size
 }
 
 // NewConfig creates a new Config and sets default values.
@@ -88,7 +90,7 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 							if strings.ContainsRune(dsn[k+1:i], ')') {
 								return nil, ErrInvalidDSNUnescaped
 							}
-							//return nil, errInvalidDSNAddr
+							// return nil, errInvalidDSNAddr
 						}
 						addr := dsn[k+1 : i-1]
 						host, port, err := net.SplitHostPort(addr)
@@ -178,6 +180,16 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			cfg.BearerToken = value
 		case "totpCode":
 			cfg.TotpCode = value
+		case "readBufferSize":
+			cfg.ReadBufferSize, err = strconv.Atoi(value)
+			if err != nil {
+				return &errors.TaosError{Code: 0xffff, ErrStr: "invalid readBufferSize value: " + value}
+			}
+		case "writeBufferSize":
+			cfg.WriteBufferSize, err = strconv.Atoi(value)
+			if err != nil {
+				return &errors.TaosError{Code: 0xffff, ErrStr: "invalid writeBufferSize value: " + value}
+			}
 		default:
 			// lazy init
 			if cfg.Params == nil {


### PR DESCRIPTION
…ections

# Description

<!-- Please briefly describe the code changes in this pull request. -->
taosWS allocates a 4 MiB write buffer per WebSocket connection. With 1,024 concurrent connections, this results in ~4 GiB of memory being allocated upfront. In workloads with little or no write traffic, most of this memory remains unused, leading to unnecessary memory overhead.

This PR introduces two new configuration options to make the buffer size configurable, allowing users to reduce memory usage based on their actual workload.

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: 

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
