### PR TITLE
fix: create new exec.Cmd instance before restarting taosadapter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,6 +361,6 @@ jobs:
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -224,10 +224,10 @@ func readJtbRow(rs *sql.Rows) {
 
 func batchInsertSql(begin int64, table string, numOfRows int) string {
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("insert into %s values ", table))
+	fmt.Fprintf(&buffer, "insert into %s values ", table)
 
 	for i := 0; i < numOfRows; i++ {
-		buffer.WriteString(fmt.Sprintf("(%d, %t, %d, %d, %d, %d, %d, %d, %d, %d, %.4f, %f, '%s', '%s')",
+		fmt.Fprintf(&buffer, "(%d, %t, %d, %d, %d, %d, %d, %d, %d, %d, %.4f, %f, '%s', '%s')",
 			begin+int64(i),
 			rand.Intn(2) == 1,      // bl
 			rand.Intn(256)-128,     // i8 [-128, 127]
@@ -242,7 +242,7 @@ func batchInsertSql(begin int64, table string, numOfRows int) string {
 			rand.Float64(),         // d64
 			randStr(20),            // bnr
 			randStr(20),            // nchr
-		))
+		)
 	}
 	buffer.WriteString(";")
 	return buffer.String()

--- a/ws/schemaless/schemaless_test.go
+++ b/ws/schemaless/schemaless_test.go
@@ -230,6 +230,7 @@ func TestSchemalessReconnect(t *testing.T) {
 	startChan := make(chan struct{})
 	go func() {
 		time.Sleep(time.Second * 10)
+		cmd = newTaosadapter(port)
 		err = startTaosadapter(cmd, port)
 		startChan <- struct{}{}
 		if err != nil {

--- a/ws/stmt/stmt_test.go
+++ b/ws/stmt/stmt_test.go
@@ -1165,6 +1165,7 @@ func TestSTMTReconnect(t *testing.T) {
 	startChan := make(chan struct{})
 	go func() {
 		time.Sleep(time.Second * 3)
+		cmd = newTaosadapter(port)
 		err = startTaosadapter(cmd, port)
 		startChan <- struct{}{}
 		if err != nil {
@@ -1180,6 +1181,7 @@ func TestSTMTReconnect(t *testing.T) {
 	stmt, err = connector.Init()
 	assert.NoError(t, err)
 	stopTaosadapter(cmd, port)
+	cmd = newTaosadapter(port)
 	err = startTaosadapter(cmd, port)
 	assert.NoError(t, err)
 	err = doRequest("create database if not exists test_ws_stmt_reconnect")

--- a/ws/tmq/consumer_test.go
+++ b/ws/tmq/consumer_test.go
@@ -1102,6 +1102,7 @@ func TestSubscribeReconnect(t *testing.T) {
 	startChan := make(chan struct{})
 	go func() {
 		time.Sleep(time.Second * 3)
+		cmd = newTaosadapter(port)
 		err = startTaosadapter(cmd, port)
 		if err != nil {
 			t.Error(err)
@@ -1133,6 +1134,7 @@ func TestSubscribeReconnect(t *testing.T) {
 			startChan <- struct{}{}
 		}()
 		time.Sleep(time.Second * 3)
+		cmd = newTaosadapter(port)
 		err = startTaosadapter(cmd, port)
 		if err != nil {
 			t.Errorf("start taosadapter failed: %v", err)


### PR DESCRIPTION
# Description

fix: create new exec.Cmd instance before restarting taosadapter

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
