### PR TITLE
sync: internal changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,17 @@ English | [简体中文](README-CN.md)
 - [1. Introduction](#1-introduction)
 - [2. Documentation](#2-documentation)
 - [3. Prerequisites](#3-prerequisites)
-- [4. Build](#4-build)
+- [4. Building](#4-building)
 - [5. Testing](#5-testing)
     - [5.1 Test Execution](#51-test-execution)
     - [5.2 Test Case Addition](#52-test-case-addition)
     - [5.3 Performance Testing](#53-performance-testing)
-- [6. CI/CD](#6-cicd)
-- [7. Submitting Issues](#7-submitting-issues)
-- [8. Submitting PRs](#8-submitting-prs)
-- [9. References](#9-references)
-- [10. License](#10-license)
+- [6. Packaging](#6-packaging)
+- [7. CI/CD](#7-cicd)
+- [8. Submitting Issues](#8-submitting-issues)
+- [9. Submitting PRs](#9-submitting-prs)
+- [10. References](#10-references)
+- [11. License](#11-license)
 
 ## 1. Introduction
 
@@ -52,14 +53,38 @@ allowing Go developers to create applications that interact with TDengine cluste
 
 ## 3. Prerequisites
 
-- Go 1.14 or above and enable CGO with `export CGO_ENABLED=1`.
+### System Requirements
+- Go >= 1.14 (1.23+ recommended)
+- For native connector: TDengine client library (`libtaos.so`)
+- For REST/WebSocket connector: no native library needed
+
+### Installing Go
+**Ubuntu/Debian & CentOS/RHEL:**
+```bash
+wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf go1.23.4.linux-amd64.tar.gz
+export PATH=/usr/local/go/bin:$PATH
+```
+
+### Native Connector Notes
+- Enable CGO with `export CGO_ENABLED=1` when building or testing the native connector.
+- Ensure `libtaos.so` is installed in a standard library search path, or set `LD_LIBRARY_PATH` accordingly.
+
+### Local Test Environment
 - TDengine has been deployed locally. For specific steps, please refer
   to [Deploy TDengine](https://docs.tdengine.com/get-started/deploy-from-package/). Please make sure taosd and
   taosAdapter have been started.
 
-## 4. Build
+## 4. Building
 
-No need to build.
+```bash
+git clone https://github.com/taosdata/driver-go.git
+cd driver-go
+go build ./...   # verify compilation
+```
+
+`driver-go` is a Go library, so `go build ./...` is the standard way to verify that all packages compile successfully.
 
 ## 5. Testing
 
@@ -72,6 +97,17 @@ No need to build.
 3. The output result `PASS` means the test passed, while `FAIL` means the test failed. For detailed information, run
    `go test -v ./...`.
 
+```bash
+# run the full test suite
+go test ./...
+
+# run with verbose output
+go test -v ./...
+```
+
+- Native connector tests require CGO enabled and a working `libtaos.so` installation.
+- REST/WebSocket tests do not require the TDengine native client library, but still require running `taosd` and `taosAdapter`.
+
 ### 5.2 Test Case Addition
 
 Add test cases to the `*_test.go` file to ensure that the test cases cover the new code.
@@ -80,12 +116,20 @@ Add test cases to the `*_test.go` file to ensure that the test cases cover the n
 
 Performance testing is in progress.
 
-## 6. CI/CD
+## 6. Packaging
+
+`driver-go` is a Go module — no separate packaging step needed. Users import it via:
+
+```go
+go get github.com/taosdata/driver-go/v3@latest
+```
+
+## 7. CI/CD
 
 - [Build Workflow](https://github.com/taosdata/driver-go/actions/workflows/build.yml)
 - [Code Coverage](https://app.codecov.io/gh/taosdata/driver-go)
 
-## 7. Submitting Issues
+## 8. Submitting Issues
 
 We welcome the submission of [GitHub Issue](https://github.com/taosdata/driver-go/issues/new?template=Blank+issue). When
 submitting, please provide the following information:
@@ -95,7 +139,7 @@ submitting, please provide the following information:
 - Connection parameters (excluding server address, username, and password)
 - TDengine version
 
-## 8. Submitting PRs
+## 9. Submitting PRs
 
 We welcome developers to contribute to this project. When submitting PRs, please follow these steps:
 
@@ -113,11 +157,11 @@ We welcome developers to contribute to this project. When submitting PRs, please
 7. After submitting the PR, if the CI passes, you can find your PR on
    the [codecov](https://app.codecov.io/gh/taosdata/driver-go/pulls) page to check the coverage.
 
-## 9. References
+## 10. References
 
 - [TDengine Official Website](https://tdengine.com/)
 - [TDengine GitHub](https://github.com/taosdata/TDengine)
 
-## 10. License
+## 11. License
 
 [MIT License](./LICENSE)

--- a/af/stmt2_test.go
+++ b/af/stmt2_test.go
@@ -102,15 +102,6 @@ func TestStmt2(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	stmt2 := conn.Stmt2(0x12345678, true)
-	if stmt2 == nil {
-		t.Errorf("Expected stmt to be not nil")
-		return
-	}
-	defer func() {
-		err = stmt2.Close()
-		assert.NoError(t, err)
-	}()
 	_, err = exec(conn, "create table if not exists all_type("+
 		"ts timestamp, "+
 		"v1 bool, "+
@@ -131,6 +122,16 @@ func TestStmt2(t *testing.T) {
 		"v16 blob"+
 		") tags(tg binary(20))")
 	assert.NoError(t, err)
+
+	stmt2 := conn.Stmt2(0x12345678, true)
+	if stmt2 == nil {
+		t.Errorf("Expected stmt to be not nil")
+		return
+	}
+	defer func() {
+		err = stmt2.Close()
+		assert.NoError(t, err)
+	}()
 	err = stmt2.Prepare("insert into ? using all_type tags(?) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
 	if !assert.NoError(t, err) {
 		return

--- a/taosWS/dsn_test.go
+++ b/taosWS/dsn_test.go
@@ -27,6 +27,7 @@ func TestParseDsn(t *testing.T) {
 		{name: "wss protocol", dsn: "user:passwd@wss(:0)/", want: &Config{User: "user", Passwd: "passwd", Net: "wss", InterpolateParams: true}},
 		{name: "params", dsn: "user:passwd@wss(:0)/?interpolateParams=false&test=1", want: &Config{User: "user", Passwd: "passwd", Net: "wss", Params: map[string]string{"test": "1"}}},
 		{name: "token", dsn: "user:passwd@wss(:0)/?interpolateParams=false&token=token", want: &Config{User: "user", Passwd: "passwd", Net: "wss", Token: "token"}},
+		{name: "skipVerify", dsn: "user:passwd@wss(:0)/?interpolateParams=false&skipVerify=true", want: &Config{User: "user", Passwd: "passwd", Net: "wss", SkipVerify: true}},
 		{name: "readTimeout", dsn: "user:passwd@wss(:0)/?writeTimeout=8s&readTimeout=10m", want: &Config{User: "user", Passwd: "passwd", Net: "wss", ReadTimeout: 10 * time.Minute, WriteTimeout: 8 * time.Second, InterpolateParams: true}},
 		{name: "compression", dsn: "user:passwd@wss(:0)/?writeTimeout=8s&readTimeout=10m&enableCompression=true", want: &Config{
 			User:              "user",

--- a/taosWS/skip_verify_test.go
+++ b/taosWS/skip_verify_test.go
@@ -1,0 +1,92 @@
+package taosWS
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	"github.com/taosdata/driver-go/v3/ws/unified/proto"
+)
+
+var skipVerifySQLUpgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+func skipVerifyBinaryAction(msg []byte) uint64 {
+	if len(msg) < 24 {
+		return 0
+	}
+	return binary.LittleEndian.Uint64(msg[16:24])
+}
+
+func skipVerifyBinaryReqID(msg []byte) uint64 {
+	if len(msg) < 8 {
+		return 0
+	}
+	return binary.LittleEndian.Uint64(msg[0:8])
+}
+
+func skipVerifyIsVersionActionText(text string) bool {
+	return strings.Contains(text, `"action":"version"`) || strings.Contains(text, `"action": "version"`)
+}
+
+func skipVerifyWssEndpointFromHTTP(serverURL string) string {
+	return "wss" + strings.TrimPrefix(serverURL, "https")
+}
+
+func TestSkipVerifyAllowsSQLWriteOverWSS(t *testing.T) {
+	var queryCount int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := skipVerifySQLUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		_, msg, err := conn.ReadMessage()
+		require.NoError(t, err)
+		require.True(t, skipVerifyIsVersionActionText(string(msg)), "unexpected version request: %s", string(msg))
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"code":0,"message":"","action":"version","version":"3.3.6.0"}`)))
+
+		_, msg, err = conn.ReadMessage()
+		require.NoError(t, err)
+		require.Contains(t, string(msg), `"action":"conn"`)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"code":0,"message":"","action":"conn","req_id":0}`)))
+
+		mt, msg, err := conn.ReadMessage()
+		require.NoError(t, err)
+		require.Equal(t, websocket.BinaryMessage, mt)
+		require.Equal(t, uint64(proto.BinaryQueryMessage), skipVerifyBinaryAction(msg))
+		atomic.AddInt32(&queryCount, 1)
+		reqID := skipVerifyBinaryReqID(msg)
+		resp := fmt.Sprintf(`{"code":0,"message":"","action":"query","req_id":%d,"id":0,"is_update":true,"affected_rows":1}`, reqID)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(resp)))
+	}))
+	defer server.Close()
+
+	dsn := fmt.Sprintf("root:taosdata@wss(%s)/?skipVerify=true", strings.TrimPrefix(skipVerifyWssEndpointFromHTTP(server.URL), "wss://"))
+	db, err := sql.Open("taosWS", dsn)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err = db.ExecContext(ctx, "insert into skip_verify_sql values(now, 1)")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), atomic.LoadInt32(&queryCount))
+}

--- a/ws/tmq/skip_verify_test.go
+++ b/ws/tmq/skip_verify_test.go
@@ -1,0 +1,106 @@
+package tmq
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	commontmq "github.com/taosdata/driver-go/v3/common/tmq"
+	"github.com/taosdata/driver-go/v3/ws/client"
+)
+
+var skipVerifyTMQUpgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+func skipVerifyTMQWSS(serverURL string) string {
+	return "wss" + strings.TrimPrefix(serverURL, "https")
+}
+
+func skipVerifyTMQIsVersion(text string) bool {
+	return strings.Contains(text, `"action":"version"`) || strings.Contains(text, `"action": "version"`)
+}
+
+func skipVerifyTMQReqID(t *testing.T, text string) uint64 {
+	t.Helper()
+	var action client.WSAction
+	require.NoError(t, json.Unmarshal([]byte(text), &action))
+	var args struct {
+		ReqID uint64 `json:"req_id"`
+	}
+	require.NoError(t, json.Unmarshal(action.Args, &args))
+	return args.ReqID
+}
+
+func TestSkipVerifyAllowsTMQSubscribeOverWSS(t *testing.T) {
+	var subscribeCount int32
+	var pollCount int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := skipVerifyTMQUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		_, msg, err := conn.ReadMessage()
+		require.NoError(t, err)
+		require.True(t, skipVerifyTMQIsVersion(string(msg)), "unexpected version request: %s", string(msg))
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"code":0,"message":"","action":"version","version":"3.3.6.0"}`)))
+
+		for {
+			_, msg, err = conn.ReadMessage()
+			require.NoError(t, err)
+			text := string(msg)
+			switch {
+			case strings.Contains(text, `"action":"subscribe"`):
+				atomic.AddInt32(&subscribeCount, 1)
+				reqID := skipVerifyTMQReqID(t, text)
+				require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf(`{"code":0,"message":"","action":"subscribe","req_id":%d}`, reqID))))
+			case strings.Contains(text, `"action":"poll"`):
+				atomic.AddInt32(&pollCount, 1)
+				reqID := skipVerifyTMQReqID(t, text)
+				require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf(`{"code":0,"message":"","action":"poll","req_id":%d,"have_message":false}`, reqID))))
+				return
+			default:
+				t.Fatalf("unexpected tmq request: %s", text)
+			}
+		}
+	}))
+	defer server.Close()
+
+	cfg := commontmq.ConfigMap{
+		"ws.url":               skipVerifyTMQWSS(server.URL),
+		"ws.skipVerify":        true,
+		"ws.message.timeout":   3 * time.Second,
+		"ws.message.writeWait": 3 * time.Second,
+		"td.connect.user":      "root",
+		"td.connect.pass":      "taosdata",
+		"group.id":             "skip_verify_group",
+		"client.id":            "skip_verify_client",
+	}
+	consumer, err := NewConsumer(&cfg)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, consumer.Close())
+	}()
+
+	require.NoError(t, consumer.Subscribe("skip_verify_topic", nil))
+	event := consumer.Poll(1)
+	if event != nil {
+		_, isErr := event.(commontmq.Error)
+		require.False(t, isErr, "unexpected tmq error: %s", event.String())
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&subscribeCount))
+	require.Equal(t, int32(1), atomic.LoadInt32(&pollCount))
+}

--- a/ws/unified/client.go
+++ b/ws/unified/client.go
@@ -1,6 +1,7 @@
 package unified
 
 import (
+	"crypto/tls"
 	"errors"
 	"net"
 	"sync"
@@ -100,6 +101,16 @@ func NewClient(cfg *Config, defaultPath string, opts ...Option) (*Client, error)
 	}
 	dialer := common.DefaultDialer
 	dialer.EnableCompression = config.EnableCompression
+	if config.SkipVerify {
+		tlsConfig := dialer.TLSClientConfig
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{}
+		} else {
+			tlsConfig = tlsConfig.Clone()
+		}
+		tlsConfig.InsecureSkipVerify = true
+		dialer.TLSClientConfig = tlsConfig
+	}
 	c := &Client{
 		config:          config,
 		failover:        failoverState,

--- a/ws/unified/config.go
+++ b/ws/unified/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	BearerToken       string
 	TotpCode          string
 	Timezone          *time.Location
+	SkipVerify        bool
 }
 
 // NewConfig creates a new Config with default timeout/reconnect behavior and copied endpoints.
@@ -82,11 +83,14 @@ func (c *Config) Normalize(defaultPath string) error {
 		c.Endpoints = []string{endpointURL.String()}
 	}
 
-	endpoints, err := NormalizeEndpoints(c.Endpoints, defaultPath)
+	endpoints, skipVerify, err := normalizeEndpointsWithLocalOptions(c.Endpoints, defaultPath)
 	if err != nil {
 		return err
 	}
 	c.Endpoints = endpoints
+	if skipVerify {
+		c.SkipVerify = true
+	}
 	if c.ReadTimeout <= 0 {
 		c.ReadTimeout = common.DefaultMessageTimeout
 	}
@@ -100,6 +104,45 @@ func (c *Config) Normalize(defaultPath string) error {
 		c.ReconnectIntervalMs = 2000
 	}
 	return nil
+}
+
+func normalizeEndpointsWithLocalOptions(endpoints []string, defaultPath string) ([]string, bool, error) {
+	cleaned := make([]string, 0, len(endpoints))
+	skipVerify := false
+	for i := 0; i < len(endpoints); i++ {
+		rawEndpoint := strings.TrimSpace(endpoints[i])
+		if rawEndpoint == "" {
+			cleaned = append(cleaned, rawEndpoint)
+			continue
+		}
+		u, err := url.Parse(rawEndpoint)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			cleaned = append(cleaned, rawEndpoint)
+			continue
+		}
+		query := u.Query()
+		values, ok := query["skipVerify"]
+		if ok {
+			for j := 0; j < len(values); j++ {
+				parsed, parseErr := strconv.ParseBool(values[j])
+				if parseErr != nil {
+					return nil, false, newInvalidConfigErrorf("invalid bool value: %s", values[j])
+				}
+				if parsed {
+					skipVerify = true
+				}
+			}
+			query.Del("skipVerify")
+			u.RawQuery = query.Encode()
+			rawEndpoint = u.String()
+		}
+		cleaned = append(cleaned, rawEndpoint)
+	}
+	normalized, err := NormalizeEndpoints(cleaned, defaultPath)
+	if err != nil {
+		return nil, false, err
+	}
+	return normalized, skipVerify, nil
 }
 
 func normalizeHostForJoinHostPort(host string) string {

--- a/ws/unified/config_test.go
+++ b/ws/unified/config_test.go
@@ -32,6 +32,35 @@ func TestNormalizeEndpointsKeepPath(t *testing.T) {
 	}
 }
 
+// TestConfigNormalizeExtractsSkipVerifyFromEndpointQuery verifies skipVerify is
+// consumed as a local TLS option and removed from websocket endpoint query.
+func TestConfigNormalizeExtractsSkipVerifyFromEndpointQuery(t *testing.T) {
+	cfg := NewConfig([]string{"wss://127.0.0.1:6041/ws?skipVerify=true&token=abc"})
+	if err := cfg.Normalize("/ws"); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.SkipVerify {
+		t.Fatal("expect skipVerify true")
+	}
+	want := []string{"wss://127.0.0.1:6041/ws?token=abc"}
+	if !reflect.DeepEqual(want, cfg.Endpoints) {
+		t.Fatalf("want %v, got %v", want, cfg.Endpoints)
+	}
+}
+
+// TestConfigNormalizeRejectsInvalidEndpointSkipVerify verifies invalid endpoint
+// skipVerify values fail before connecting.
+func TestConfigNormalizeRejectsInvalidEndpointSkipVerify(t *testing.T) {
+	cfg := NewConfig([]string{"wss://127.0.0.1:6041/ws?skipVerify=bad"})
+	err := cfg.Normalize("/ws")
+	if err == nil {
+		t.Fatal("expect invalid skipVerify error")
+	}
+	if err.Error() != "invalid bool value: bad" {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+}
+
 // TestNormalizeEndpointsInvalidScheme verifies the expected behavior for this scenario.
 func TestNormalizeEndpointsInvalidScheme(t *testing.T) {
 	_, err := NormalizeEndpoints([]string{"http://127.0.0.1:6041"}, "/ws")

--- a/ws/unified/dsn.go
+++ b/ws/unified/dsn.go
@@ -181,6 +181,7 @@ func NewConfigFromDSN(dsn string, defaultPath string) (*Config, error) {
 	cfg.TotpCode = parsed.TotpCode
 	cfg.BearerToken = parsed.BearerToken
 	cfg.AutoReconnect = parsed.AutoReconnect
+	cfg.SkipVerify = parsed.SkipVerify
 	if parsed.ChanLength != 0 {
 		cfg.ChanLength = parsed.ChanLength
 	}
@@ -253,6 +254,12 @@ func parseDSNParams(cfg *Config, params string) error {
 				return newInvalidDSNErrorf("invalid autoReconnect value: %s", value)
 			}
 			cfg.AutoReconnect = parsed
+		case "skipVerify":
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return newInvalidDSNErrorf("invalid bool value: %s", value)
+			}
+			cfg.SkipVerify = parsed
 		case "chanLength":
 			parsed, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {

--- a/ws/unified/dsn_test.go
+++ b/ws/unified/dsn_test.go
@@ -196,6 +196,43 @@ func TestParseDSNMultiParamsCombination(t *testing.T) {
 	}
 }
 
+// TestParseDSNSkipVerify verifies skipVerify is parsed as a websocket TLS option.
+func TestParseDSNSkipVerify(t *testing.T) {
+	cfg, err := ParseDSN("user:passwd@wss(:0)/?skipVerify=true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.SkipVerify {
+		t.Fatal("expect skipVerify true")
+	}
+}
+
+// TestParseDSNSkipVerifyInvalid verifies invalid skipVerify values are rejected.
+func TestParseDSNSkipVerifyInvalid(t *testing.T) {
+	_, err := ParseDSN("user:passwd@wss(:0)/?skipVerify=bad")
+	if err == nil {
+		t.Fatal("expect invalid skipVerify error")
+	}
+	if err.Error() != "invalid bool value: bad" {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+}
+
+// TestNewConfigFromDSNSkipVerify verifies NewConfigFromDSN preserves skipVerify
+// while rebuilding normalized endpoints.
+func TestNewConfigFromDSNSkipVerify(t *testing.T) {
+	cfg, err := NewConfigFromDSN("user:passwd@wss(127.0.0.1:6041)/db?skipVerify=true", "/ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.SkipVerify {
+		t.Fatal("expect skipVerify true")
+	}
+	if len(cfg.Endpoints) != 1 || cfg.Endpoints[0] != "wss://127.0.0.1:6041/ws" {
+		t.Fatalf("unexpected endpoints: %+v", cfg.Endpoints)
+	}
+}
+
 // TestNewConfigFromDSNMultiAddrListIPv6Failover verifies normalized endpoints for IPv6 multi-node DSN.
 func TestNewConfigFromDSNMultiAddrListIPv6Failover(t *testing.T) {
 	cfg, err := NewConfigFromDSN("user:passwd@wss([2001:db8::1]:6041,[2001:db8::2]:6042)/db?token=tk1", "/ws/v1")

--- a/ws/unified/skip_verify_test.go
+++ b/ws/unified/skip_verify_test.go
@@ -1,0 +1,158 @@
+package unified
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	commontmq "github.com/taosdata/driver-go/v3/common/tmq"
+	"github.com/taosdata/driver-go/v3/ws/client"
+)
+
+func wssEndpointFromHTTP(serverURL string) string {
+	return "wss" + strings.TrimPrefix(serverURL, "https")
+}
+
+func startTLSSkipVerifyServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func readTextActionMessage(t *testing.T, conn *websocket.Conn) string {
+	t.Helper()
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+	return string(msg)
+}
+
+func writeTextResponse(t *testing.T, conn *websocket.Conn, response string) {
+	t.Helper()
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(response)))
+}
+
+func reqIDFromTextAction(t *testing.T, text string) uint64 {
+	t.Helper()
+	var action client.WSAction
+	require.NoError(t, json.Unmarshal([]byte(text), &action))
+	var args struct {
+		ReqID uint64 `json:"req_id"`
+	}
+	require.NoError(t, json.Unmarshal(action.Args, &args))
+	return args.ReqID
+}
+
+func handleVersionAndConnect(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	text := readTextActionMessage(t, conn)
+	require.True(t, isVersionActionText(text), "unexpected version request: %s", text)
+	require.NoError(t, writeVersionResponse(conn))
+
+	text = readTextActionMessage(t, conn)
+	require.Contains(t, text, `"action":"conn"`)
+	writeTextResponse(t, conn, `{"code":0,"message":"","action":"conn","req_id":0}`)
+}
+
+func TestSkipVerifyAllowsSchemalessWriteOverWSS(t *testing.T) {
+	var insertCount int32
+	server := startTLSSkipVerifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		conn, err := schemalessTestUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		handleVersionAndConnect(t, conn)
+
+		text := readTextActionMessage(t, conn)
+		require.Contains(t, text, `"action":"insert"`)
+		require.Contains(t, text, "measurement,host=host1")
+		atomic.AddInt32(&insertCount, 1)
+		writeTextResponse(t, conn, `{"code":0,"message":"","action":"insert","req_id":1}`)
+	})
+
+	cfg := NewConfig([]string{wssEndpointFromHTTP(server.URL)})
+	cfg.User = "root"
+	cfg.Passwd = "taosdata"
+	cfg.SkipVerify = true
+
+	client, err := NewClient(cfg, "/ws")
+	require.NoError(t, err)
+	defer client.Close()
+	require.NoError(t, client.Connect())
+
+	err = client.SchemalessInsert(1, "measurement,host=host1 field1=2i 1577837300000", 1, "ms", 0, "")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), atomic.LoadInt32(&insertCount))
+}
+
+func TestSkipVerifyAllowsTMQSubscribeOverWSS(t *testing.T) {
+	var subscribeCount int32
+	var pollCount int32
+	server := startTLSSkipVerifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		conn, err := queryLifecycleUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		text := readTextActionMessage(t, conn)
+		require.True(t, isVersionActionText(text), "unexpected version request: %s", text)
+		require.NoError(t, writeVersionResponse(conn))
+
+		for {
+			text = readTextActionMessage(t, conn)
+			switch {
+			case strings.Contains(text, `"action":"subscribe"`):
+				atomic.AddInt32(&subscribeCount, 1)
+				reqID := reqIDFromTextAction(t, text)
+				writeTextResponse(t, conn, fmt.Sprintf(`{"code":0,"message":"","action":"subscribe","req_id":%d}`, reqID))
+			case strings.Contains(text, `"action":"poll"`):
+				atomic.AddInt32(&pollCount, 1)
+				reqID := reqIDFromTextAction(t, text)
+				writeTextResponse(t, conn, fmt.Sprintf(`{"code":0,"message":"","action":"poll","req_id":%d,"have_message":false}`, reqID))
+				return
+			default:
+				t.Fatalf("unexpected tmq request: %s", text)
+			}
+		}
+	})
+
+	cfg := commontmq.ConfigMap{
+		"ws.url":               wssEndpointFromHTTP(server.URL),
+		"ws.skipVerify":        true,
+		"ws.message.timeout":   3 * time.Second,
+		"ws.message.writeWait": 3 * time.Second,
+		"td.connect.user":      "root",
+		"td.connect.pass":      "taosdata",
+		"group.id":             "skip_verify_group",
+		"client.id":            "skip_verify_client",
+	}
+	consumer, err := NewTMQConsumer(&cfg)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, consumer.Close())
+	}()
+
+	require.NoError(t, consumer.Subscribe("skip_verify_topic", nil))
+	event := consumer.Poll(1)
+	_, isErr := event.(commontmq.Error)
+	if event != nil {
+		require.False(t, isErr, "unexpected tmq error: %s", event.String())
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&subscribeCount))
+	require.Equal(t, int32(1), atomic.LoadInt32(&pollCount))
+}

--- a/ws/unified/tmq_config.go
+++ b/ws/unified/tmq_config.go
@@ -23,6 +23,7 @@ type config struct {
 	SnapshotEnable       string
 	WithTableName        string
 	EnableCompression    bool
+	SkipVerify           bool
 	AutoReconnect        bool
 	ReconnectIntervalMs  int
 	ReconnectRetryCount  int
@@ -106,6 +107,10 @@ func (c *config) setWithTableName(withTableName string) {
 
 func (c *config) setEnableCompression(enableCompression bool) {
 	c.EnableCompression = enableCompression
+}
+
+func (c *config) setSkipVerify(skipVerify bool) {
+	c.SkipVerify = skipVerify
 }
 
 func (c *config) setAutoReconnect(autoReconnect bool) {

--- a/ws/unified/tmq_config_validation_test.go
+++ b/ws/unified/tmq_config_validation_test.go
@@ -187,6 +187,16 @@ func TestTMQConfigMapToConfigWrong(t *testing.T) {
 			wantErr: "ws.message.writeWait cannot be less than 1 second",
 		},
 		{
+			name: "ws.skipVerify",
+			args: args{
+				m: commontmq.ConfigMap{
+					"ws.url":        "ws://127.0.0.1:6041",
+					"ws.skipVerify": 123,
+				},
+			},
+			wantErr: "ws.skipVerify expects type bool, not int",
+		},
+		{
 			name: "ws.autoReconnect",
 			args: args{
 				m: commontmq.ConfigMap{
@@ -255,5 +265,18 @@ func TestTMQConfigMapToConfigWrong(t *testing.T) {
 				assert.Equal(t, tt.wantErr, err.Error())
 			}
 		})
+	}
+}
+
+// TestTMQConfigMapToConfigSkipVerify verifies ws.skipVerify is stored as a
+// websocket client TLS option.
+func TestTMQConfigMapToConfigSkipVerify(t *testing.T) {
+	cfg, err := configMapToConfig(commontmq.ConfigMap{
+		"ws.url":        "wss://127.0.0.1:6041",
+		"ws.skipVerify": true,
+	})
+	assert.NoError(t, err)
+	if assert.NotNil(t, cfg) {
+		assert.True(t, cfg.SkipVerify)
 	}
 }

--- a/ws/unified/tmq_consumer.go
+++ b/ws/unified/tmq_consumer.go
@@ -91,6 +91,7 @@ func NewTMQConsumer(conf *tmq.ConfigMap) (*TMQConsumer, error) {
 	unifiedCfg.ReadTimeout = config.MessageTimeout
 	unifiedCfg.WriteTimeout = config.WriteWait
 	unifiedCfg.EnableCompression = config.EnableCompression
+	unifiedCfg.SkipVerify = config.SkipVerify
 	unifiedCfg.AutoReconnect = config.AutoReconnect
 	unifiedCfg.ReconnectIntervalMs = config.ReconnectIntervalMs
 	unifiedCfg.ReconnectRetryCount = config.ReconnectRetryCount
@@ -179,6 +180,7 @@ var excludeConfig = map[string]struct{}{
 	"experimental.snapshot.enable": {},
 	"msg.with.table.name":          {},
 	"ws.message.enableCompression": {},
+	"ws.skipVerify":                {},
 	"ws.autoReconnect":             {},
 	"ws.reconnectIntervalMs":       {},
 	"ws.reconnectRetryCount":       {},
@@ -252,6 +254,10 @@ func configMapToConfig(m tmq.ConfigMap) (*config, error) {
 	if err != nil {
 		return nil, err
 	}
+	skipVerify, err := m.Get("ws.skipVerify", false)
+	if err != nil {
+		return nil, err
+	}
 	autoReconnect, err := m.Get("ws.autoReconnect", false)
 	if err != nil {
 		return nil, err
@@ -296,6 +302,7 @@ func configMapToConfig(m tmq.ConfigMap) (*config, error) {
 	config.setSnapshotEnable(enableSnapshot.(string))
 	config.setWithTableName(withTableName.(string))
 	config.setEnableCompression(enableCompression.(bool))
+	config.setSkipVerify(skipVerify.(bool))
 	config.setAutoReconnect(autoReconnect.(bool))
 	config.setReconnectIntervalMs(reconnectIntervalMs.(int))
 	config.setReconnectRetryCount(reconnectRetryCount.(int))

--- a/ws/unified/tmq_failover_multiadapter_integration_test.go
+++ b/ws/unified/tmq_failover_multiadapter_integration_test.go
@@ -287,17 +287,24 @@ func newIntegrationTMQConsumer(t *testing.T, ports []string, db string) *TMQCons
 		endpoints = append(endpoints, fmt.Sprintf("ws://127.0.0.1:%s", ports[i]))
 	}
 	cfg := commontmq.ConfigMap{
-		"ws.url":                 strings.Join(endpoints, ","),
-		"td.connect.user":        "root",
-		"td.connect.pass":        "taosdata",
-		"group.id":               fmt.Sprintf("tmq_group_%d", time.Now().UnixNano()),
-		"client.id":              fmt.Sprintf("tmq_client_%d", time.Now().UnixNano()),
-		"auto.offset.reset":      "earliest",
-		"enable.auto.commit":     "false",
-		"msg.with.table.name":    "true",
-		"session.timeout.ms":     "10000",
-		"max.poll.interval.ms":   "30000",
-		"ws.message.timeout":     3 * time.Second,
+		"ws.url":               strings.Join(endpoints, ","),
+		"td.connect.user":      "root",
+		"td.connect.pass":      "taosdata",
+		"group.id":             fmt.Sprintf("tmq_group_%d", time.Now().UnixNano()),
+		"client.id":            fmt.Sprintf("tmq_client_%d", time.Now().UnixNano()),
+		"auto.offset.reset":    "earliest",
+		"enable.auto.commit":   "false",
+		"msg.with.table.name":  "true",
+		"session.timeout.ms":   "10000",
+		"max.poll.interval.ms": "30000",
+		// Subscribe/poll/commit all share this read timeout. The dual-node
+		// failover scenarios that use this consumer cold-start three adapters
+		// and subscribe under ASAN instrumentation, where the first round's
+		// subscribe round-trip has been observed to take ~8s (job 114416,
+		// test-asan-3360). 3s was too tight and flaked round_01; 10s covers the
+		// slow cold start while staying far below DefaultMessageTimeout (5m) so
+		// a genuine hang still fails fast.
+		"ws.message.timeout":     10 * time.Second,
 		"ws.message.writeWait":   3 * time.Second,
 		"ws.autoReconnect":       true,
 		"ws.reconnectIntervalMs": 50,


### PR DESCRIPTION
Sync internal changes.

Base: `driver-go/main` at `1a399eec576` (`fix: ci build adapter (#368)`).
Source snapshot: `tsdb/main:source/taos-connector-go` after GitLab MR !917.

This PR preserves the original commit information by replaying the TSDB subtree commits onto `driver-go/main`:

- `d9072ea0ae4` `feat: dual-source deps and comprehensive docs/packaging (cherry-pick to main) (rd-public/tsdb!352)`
- `617c7e43291` `chore: add go connector gitlab ci (rd-public/tsdb!767)`
- `e66a9750cb2` `feat: add websocket skipVerify support (rd-public/tsdb!880)`

Verification:

- Confirmed the PR branch contents match `tsdb/main:source/taos-connector-go` exactly with `git diff --quiet HEAD main:source/taos-connector-go`.
- Confirmed the PR diff is limited to the remaining TSDB subtree changes after upstream PR #368.