### PR TITLE
feat: sync TSDB connector updates

### DIFF
--- a/common/tmq/event_test.go
+++ b/common/tmq/event_test.go
@@ -55,7 +55,7 @@ func TestMetaMessage_String(t *testing.T) {
 		meta:   meta,
 	}
 
-	want := `MetaMessage: test-topic[test-db]:{"type":"type","tableName":"table","tableType":"tableType","createList":null,"columns":null,"using":"","tagNum":0,"tags":null,"tableNameList":null,"alterType":0,"colName":"","colNewName":"","colType":0,"colLength":0,"colValue":"","colValueNull":false}`
+	want := `MetaMessage: test-topic[test-db]:{"type":"type","tableName":"table","tableType":"tableType","createList":null,"columns":null,"using":"","tagNum":0,"tags":null,"tableNameList":null,"alterType":0,"colName":"","colNewName":"","colType":0,"colLength":0,"colValue":"","colValueNull":false,"baseOn":null,"ownColStart":0,"ownTagStart":0}`
 
 	if got := message.String(); got != want {
 		t.Errorf("MetaMessage.String() = %v, want %v", got, want)
@@ -90,7 +90,7 @@ func TestMetaDataMessage_String(t *testing.T) {
 		metaData: metaData,
 	}
 
-	want := `MetaDataMessage: test-topic[test-db]:{"Meta":{"type":"type","tableName":"table","tableType":"tableType","createList":null,"columns":null,"using":"","tagNum":0,"tags":null,"tableNameList":null,"alterType":0,"colName":"","colNewName":"","colType":0,"colLength":0,"colValue":"","colValueNull":false},"Data":[{"TableName":"table1","Data":[[1,"data1"]]},{"TableName":"table2","Data":[[2,"data2"]]}]}`
+	want := `MetaDataMessage: test-topic[test-db]:{"Meta":{"type":"type","tableName":"table","tableType":"tableType","createList":null,"columns":null,"using":"","tagNum":0,"tags":null,"tableNameList":null,"alterType":0,"colName":"","colNewName":"","colType":0,"colLength":0,"colValue":"","colValueNull":false,"baseOn":null,"ownColStart":0,"ownTagStart":0},"Data":[{"TableName":"table1","Data":[[1,"data1"]]},{"TableName":"table2","Data":[[2,"data2"]]}]}`
 	if got := message.String(); got != want {
 		t.Errorf("MetaDataMessage.String() = %v, want %v", got, want)
 	}

--- a/common/tmq/tmq.go
+++ b/common/tmq/tmq.go
@@ -19,6 +19,12 @@ type Meta struct {
 	ColLength     int           `json:"colLength"`
 	ColValue      string        `json:"colValue"`
 	ColValueNull  bool          `json:"colValueNull"`
+	// VST inheritance (BASE ON): present for create-super and alterType 22/23.
+	// BaseOn holds the parent super table names; OwnColStart/OwnTagStart mark the
+	// first own (non-inherited) column/tag in the merged Columns/Tags slices.
+	BaseOn      []string `json:"baseOn"`
+	OwnColStart int      `json:"ownColStart"`
+	OwnTagStart int      `json:"ownTagStart"`
 }
 
 type Tag struct {

--- a/common/tmq/tmq_test.go
+++ b/common/tmq/tmq_test.go
@@ -69,6 +69,72 @@ func TestDropJson(t *testing.T) {
 	t.Log(obj)
 }
 
+const createBaseOnJson = `{
+    "type": "create",
+    "tableName": "vst_child",
+    "tableType": "super",
+    "columns": [
+        {"name": "ts", "type": 9, "length": 0},
+        {"name": "own_c", "type": 4, "length": 0}
+    ],
+    "tags": [
+        {"name": "own_t", "type": 4, "length": 0}
+    ],
+    "baseOn": ["vst_parent_a", "vst_parent_b"],
+    "ownColStart": 2,
+    "ownTagStart": 1
+}`
+
+const alterBaseOnJson = `{
+    "type": "alter",
+    "tableName": "vst_child",
+    "tableType": "super",
+    "alterType": 22,
+    "baseOn": ["vst_parent_a"]
+}`
+
+// VST inheritance (BASE ON) fields must deserialize into Meta.
+func TestCreateBaseOnJson(t *testing.T) {
+	var obj Meta
+	if err := json.Unmarshal([]byte(createBaseOnJson), &obj); err != nil {
+		t.Fatalf("unmarshal create base-on meta: %v", err)
+	}
+	if !reflect.DeepEqual(obj.BaseOn, []string{"vst_parent_a", "vst_parent_b"}) {
+		t.Fatalf("BaseOn = %v, want [vst_parent_a vst_parent_b]", obj.BaseOn)
+	}
+	if obj.OwnColStart != 2 {
+		t.Fatalf("OwnColStart = %d, want 2", obj.OwnColStart)
+	}
+	if obj.OwnTagStart != 1 {
+		t.Fatalf("OwnTagStart = %d, want 1", obj.OwnTagStart)
+	}
+}
+
+// A non-inherited create meta leaves BASE ON fields at their zero values.
+func TestCreateJsonNoBaseOn(t *testing.T) {
+	var obj Meta
+	if err := json.Unmarshal([]byte(createJson), &obj); err != nil {
+		t.Fatalf("unmarshal create meta: %v", err)
+	}
+	if obj.BaseOn != nil {
+		t.Fatalf("BaseOn = %v, want nil for non-inherited table", obj.BaseOn)
+	}
+}
+
+// alterType 22/23 (ADD/DROP BASE ON) deserialize with their parent list.
+func TestAlterBaseOnJson(t *testing.T) {
+	var obj Meta
+	if err := json.Unmarshal([]byte(alterBaseOnJson), &obj); err != nil {
+		t.Fatalf("unmarshal alter base-on meta: %v", err)
+	}
+	if obj.AlterType != 22 {
+		t.Fatalf("AlterType = %d, want 22", obj.AlterType)
+	}
+	if !reflect.DeepEqual(obj.BaseOn, []string{"vst_parent_a"}) {
+		t.Fatalf("BaseOn = %v, want [vst_parent_a]", obj.BaseOn)
+	}
+}
+
 func TestOffset_String(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ws/unified/client.go
+++ b/ws/unified/client.go
@@ -18,7 +18,7 @@ var (
 	defaultUnifiedErrHandler = func(error) {}
 )
 
-type BootstrapFunc func(conn *websocket.Conn) error
+type BootstrapFunc func(conn *websocket.Conn, endpointURL string) error
 
 type DialFunc func(endpoint string) (*websocket.Conn, error)
 
@@ -69,6 +69,7 @@ type Client struct {
 	// Atomic runtime snapshot used by hot paths to avoid c.lock read contention.
 	runtimeSnapshot      atomic.Value
 	runtimeSnapshotReady uint32
+	instancesFetched     uint32
 
 	// normal connect support
 	normalConnectLock sync.Mutex
@@ -94,6 +95,14 @@ func NewClient(cfg *Config, defaultPath string, opts ...Option) (*Client, error)
 	config.Endpoints = append([]string(nil), cfg.Endpoints...)
 	if err := config.Normalize(defaultPath); err != nil {
 		return nil, err
+	}
+	if config.AdapterHA {
+		seeds := hostPortsOf(config.Endpoints)
+		expanded := globalClusterRegistry.expand(seeds)
+		if len(expanded) > len(seeds) && len(config.Endpoints) > 0 {
+			discoveredURLs := formatHostPortsToURLs(expanded, config.Endpoints[0])
+			config.Endpoints = mergeURLList(config.Endpoints, discoveredURLs)
+		}
 	}
 	failoverState, err := newFailoverState(config.Endpoints)
 	if err != nil {
@@ -242,7 +251,7 @@ func (c *Client) connectWithCandidates(candidates []endpointCandidate, bootstrap
 			continue
 		}
 		if bootstrap != nil {
-			if err = bootstrap(conn); err != nil {
+			if err = bootstrap(conn, candidate.URL); err != nil {
 				if conn != nil {
 					_ = conn.Close()
 				}
@@ -421,6 +430,46 @@ func (c *Client) removePendingRequest(reqID uint64, expected *pendingRequest) *p
 // Runtime returns the currently active runtime client pointer.
 func (c *Client) runtimeClient() *client.Client {
 	return c.loadRuntimeSnapshot().runtime
+}
+
+func (c *Client) activeEndpointURL() string {
+	if c == nil || c.failover == nil {
+		return ""
+	}
+	return c.failover.active().URL
+}
+
+func (c *Client) mergeInstances(connectedURL string, instances []string) {
+	if c == nil || c.failover == nil {
+		return
+	}
+	discovered := validUniqueHostPorts(instances)
+	seedHostPorts := hostPortsOf(c.failover.endpointsCopy())
+	toRegister := unionHostPorts(seedHostPorts, discovered)
+	if len(toRegister) > 0 {
+		globalClusterRegistry.update(toRegister)
+	}
+	if len(discovered) == 0 {
+		return
+	}
+	urls := formatHostPortsToURLs(discovered, connectedURL)
+	if added := c.failover.mergeEndpoints(urls); added > 0 {
+		tLog.Infof(0, "adapter HA: discovered %d new endpoint(s)", added)
+	}
+}
+
+func (c *Client) mergeAdapterHAInstancesOnce(instancesFetched *uint32, connectedURL string, listInstances *[]string) {
+	if c == nil || !c.config.AdapterHA || instancesFetched == nil {
+		return
+	}
+	if !atomic.CompareAndSwapUint32(instancesFetched, 0, 1) {
+		return
+	}
+	instances := []string(nil)
+	if listInstances != nil {
+		instances = *listInstances
+	}
+	c.mergeInstances(connectedURL, instances)
 }
 
 func (c *Client) publishRuntimeSnapshotLocked() {

--- a/ws/unified/client_adapter_ha_test.go
+++ b/ws/unified/client_adapter_ha_test.go
@@ -1,0 +1,117 @@
+package unified
+
+import (
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func withFreshClusterRegistry(t *testing.T) *clusterRegistry {
+	t.Helper()
+	old := globalClusterRegistry
+	registry := newClusterRegistry()
+	globalClusterRegistry = registry
+	t.Cleanup(func() {
+		globalClusterRegistry = old
+	})
+	return registry
+}
+
+func TestNewClientAdapterHAExpandsEndpointsFromGlobalRegistry(t *testing.T) {
+	registry := withFreshClusterRegistry(t)
+	registry.update([]string{"seed:6041", "peer:6041"})
+
+	cfg := NewConfig([]string{"wss://seed:6041/ws?token=abc"})
+	cfg.AdapterHA = true
+	c, err := NewClient(cfg, "/ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := c.failover.endpointsCopy()
+	want := []string{
+		"wss://seed:6041/ws?token=abc",
+		"wss://peer:6041/ws?token=abc",
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestNewClientAdapterHADisabledDoesNotReadRegistry(t *testing.T) {
+	registry := withFreshClusterRegistry(t)
+	registry.update([]string{"seed:6041", "peer:6041"})
+
+	cfg := NewConfig([]string{"wss://seed:6041/ws?token=abc"})
+	c, err := NewClient(cfg, "/ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := c.failover.endpointsCopy()
+	want := []string{"wss://seed:6041/ws?token=abc"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestClientMergeInstancesRegistersSeedsAndAppendsDiscoveredEndpoints(t *testing.T) {
+	registry := withFreshClusterRegistry(t)
+	failover, err := newFailoverState([]string{"wss://seed:6041/ws?token=abc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &Client{failover: failover}
+
+	c.mergeInstances("wss://seed:6041/ws?token=abc", []string{"peer:6041", "peer:6041", "bad"})
+
+	gotEndpoints := failover.endpointsCopy()
+	wantEndpoints := []string{
+		"wss://seed:6041/ws?token=abc",
+		"wss://peer:6041/ws?token=abc",
+	}
+	if !reflect.DeepEqual(wantEndpoints, gotEndpoints) {
+		t.Fatalf("want endpoints %v, got %v", wantEndpoints, gotEndpoints)
+	}
+
+	gotRegistry := registry.expand([]string{"seed:6041"})
+	wantRegistry := []string{"seed:6041", "peer:6041"}
+	if !reflect.DeepEqual(wantRegistry, gotRegistry) {
+		t.Fatalf("want registry expansion %v, got %v", wantRegistry, gotRegistry)
+	}
+}
+
+func TestClientMergeAdapterHAInstancesOnceUsesFlag(t *testing.T) {
+	registry := withFreshClusterRegistry(t)
+	failover, err := newFailoverState([]string{"wss://seed:6041/ws?token=abc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &Client{
+		config:   Config{AdapterHA: true},
+		failover: failover,
+	}
+	var fetched uint32
+	firstInstances := []string{"peer:6041"}
+	secondInstances := []string{"other:6041"}
+
+	c.mergeAdapterHAInstancesOnce(&fetched, "wss://seed:6041/ws?token=abc", &firstInstances)
+	c.mergeAdapterHAInstancesOnce(&fetched, "wss://seed:6041/ws?token=abc", &secondInstances)
+
+	if got := atomic.LoadUint32(&fetched); got != 1 {
+		t.Fatalf("want fetched flag 1, got %d", got)
+	}
+	gotEndpoints := failover.endpointsCopy()
+	wantEndpoints := []string{
+		"wss://seed:6041/ws?token=abc",
+		"wss://peer:6041/ws?token=abc",
+	}
+	if !reflect.DeepEqual(wantEndpoints, gotEndpoints) {
+		t.Fatalf("want endpoints %v, got %v", wantEndpoints, gotEndpoints)
+	}
+	gotRegistry := registry.expand([]string{"seed:6041"})
+	wantRegistry := []string{"seed:6041", "peer:6041"}
+	if !reflect.DeepEqual(wantRegistry, gotRegistry) {
+		t.Fatalf("want registry expansion %v, got %v", wantRegistry, gotRegistry)
+	}
+}

--- a/ws/unified/client_test.go
+++ b/ws/unified/client_test.go
@@ -1,6 +1,7 @@
 package unified
 
 import (
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -184,6 +185,28 @@ func TestClientCloseRejectsConnect(t *testing.T) {
 	c.Close()
 	if err = c.connectWithBootstrap(nil); err == nil {
 		t.Fatal("expect close error")
+	}
+}
+
+func TestConnectWithCandidatesPassesCandidateURLToBootstrap(t *testing.T) {
+	cfg := NewConfig([]string{"ws://a:1/ws"})
+	c, err := NewClient(cfg, "/ws", WithDialFunc(func(endpoint string) (*websocket.Conn, error) {
+		return nil, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sentinel := errors.New("stop after bootstrap")
+	gotEndpoint := ""
+	err = c.connectWithCandidates([]endpointCandidate{{Index: 0, URL: "ws://candidate:6041/ws?token=abc"}}, func(_ *websocket.Conn, endpointURL string) error {
+		gotEndpoint = endpointURL
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel bootstrap error, got %v", err)
+	}
+	if gotEndpoint != "ws://candidate:6041/ws?token=abc" {
+		t.Fatalf("bootstrap endpointURL = %q", gotEndpoint)
 	}
 }
 

--- a/ws/unified/cluster_registry.go
+++ b/ws/unified/cluster_registry.go
@@ -1,0 +1,164 @@
+package unified
+
+import (
+	"net"
+	"strconv"
+	"sync"
+
+	tLog "github.com/taosdata/driver-go/v3/log"
+)
+
+type cluster struct {
+	mu    sync.Mutex
+	addrs []string
+}
+
+func newCluster(addrs []string) *cluster {
+	copyAddrs := append([]string(nil), addrs...)
+	return &cluster{addrs: copyAddrs}
+}
+
+func (c *cluster) addresses() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.addrs))
+	copy(out, c.addrs)
+	return out
+}
+
+func (c *cluster) addAddresses(addrs []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.addrs = appendUnique(c.addrs, addrs)
+}
+
+type clusterRegistry struct {
+	mu                sync.Mutex
+	endpointToCluster map[string]*cluster
+}
+
+func newClusterRegistry() *clusterRegistry {
+	return &clusterRegistry{
+		endpointToCluster: make(map[string]*cluster),
+	}
+}
+
+// globalClusterRegistry is process-wide and keyed only by host:port.
+// Adapter HA assumes host:port uniquely identifies one adapter endpoint in the
+// process network namespace; clients for different logical clusters must not
+// reuse the same host:port unless they intentionally share discovered topology.
+var globalClusterRegistry = newClusterRegistry()
+
+func (r *clusterRegistry) expand(seeds []string) []string {
+	valid := validUniqueHostPorts(seeds)
+	if len(valid) == 0 {
+		return append([]string(nil), seeds...)
+	}
+
+	r.mu.Lock()
+	clusters := r.findClustersLocked(valid)
+	if len(clusters) != 1 {
+		r.mu.Unlock()
+		if len(clusters) > 1 {
+			tLog.Warnf(0, "adapter HA: seeds match multiple clusters, seeds: %v", valid)
+		}
+		return append([]string(nil), seeds...)
+	}
+	c := clusters[0]
+	r.mu.Unlock()
+
+	return unionHostPorts(seeds, c.addresses())
+}
+
+func (r *clusterRegistry) update(addrs []string) {
+	valid := validUniqueHostPorts(addrs)
+	if len(valid) == 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	clusters := r.findClustersLocked(valid)
+	var c *cluster
+	switch len(clusters) {
+	case 0:
+		c = newCluster(valid)
+	case 1:
+		c = clusters[0]
+		c.addAddresses(valid)
+	default:
+		tLog.Warnf(0, "adapter HA: discovered addresses match multiple clusters, addrs: %v", valid)
+		return
+	}
+
+	for i := 0; i < len(valid); i++ {
+		r.endpointToCluster[valid[i]] = c
+	}
+}
+
+func (r *clusterRegistry) findClustersLocked(addrs []string) []*cluster {
+	seen := make(map[*cluster]struct{})
+	clusters := make([]*cluster, 0, 1)
+	for i := 0; i < len(addrs); i++ {
+		c, ok := r.endpointToCluster[addrs[i]]
+		if !ok || c == nil {
+			continue
+		}
+		if _, exists := seen[c]; exists {
+			continue
+		}
+		seen[c] = struct{}{}
+		clusters = append(clusters, c)
+	}
+	return clusters
+}
+
+func validUniqueHostPorts(addrs []string) []string {
+	seen := make(map[string]struct{}, len(addrs))
+	out := make([]string, 0, len(addrs))
+	for i := 0; i < len(addrs); i++ {
+		addr := addrs[i]
+		if !isValidHostPort(addr) {
+			if addr != "" {
+				tLog.Warnf(0, "adapter HA: invalid host:port ignored: %s", addr)
+			}
+			continue
+		}
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
+		out = append(out, addr)
+	}
+	return out
+}
+
+func isValidHostPort(addr string) bool {
+	host, portString, err := net.SplitHostPort(addr)
+	if err != nil || host == "" || portString == "" {
+		return false
+	}
+	port, err := strconv.Atoi(portString)
+	return err == nil && port >= 1 && port <= 65535
+}
+
+func unionHostPorts(first []string, second []string) []string {
+	return appendUnique(first, second)
+}
+
+func appendUnique(first []string, second []string) []string {
+	seen := make(map[string]struct{}, len(first)+len(second))
+	out := make([]string, 0, len(first)+len(second))
+	for _, values := range [][]string{first, second} {
+		for i := 0; i < len(values); i++ {
+			addr := values[i]
+			if _, ok := seen[addr]; ok {
+				continue
+			}
+			seen[addr] = struct{}{}
+			out = append(out, addr)
+		}
+	}
+	return out
+}

--- a/ws/unified/cluster_registry_test.go
+++ b/ws/unified/cluster_registry_test.go
@@ -1,0 +1,102 @@
+package unified
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestClusterRegistryExpandDoesNotCreateCluster(t *testing.T) {
+	registry := newClusterRegistry()
+	seeds := []string{"a:1", "b:2"}
+
+	got := registry.expand(seeds)
+
+	if !reflect.DeepEqual(seeds, got) {
+		t.Fatalf("want seeds unchanged, got %v", got)
+	}
+	if len(registry.endpointToCluster) != 0 {
+		t.Fatalf("expand must not create clusters, got %d mappings", len(registry.endpointToCluster))
+	}
+}
+
+func TestClusterRegistryUpdateLetsSeedInheritDiscoveredInstances(t *testing.T) {
+	registry := newClusterRegistry()
+
+	registry.update([]string{"seed:6041", "peer:6041"})
+
+	got := registry.expand([]string{"seed:6041"})
+	want := []string{"seed:6041", "peer:6041"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestClusterRegistryUpdateConnectsClustersTransitively(t *testing.T) {
+	registry := newClusterRegistry()
+
+	registry.update([]string{"a:1", "b:2"})
+	registry.update([]string{"b:2", "c:3"})
+
+	got := registry.expand([]string{"a:1"})
+	want := []string{"a:1", "b:2", "c:3"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestClusterRegistryProtectsAgainstMultiClusterSeeds(t *testing.T) {
+	registry := newClusterRegistry()
+	registry.update([]string{"a:1", "b:2"})
+	registry.update([]string{"c:3", "d:4"})
+
+	seeds := []string{"a:1", "c:3"}
+	got := registry.expand(seeds)
+	if !reflect.DeepEqual(seeds, got) {
+		t.Fatalf("multi-cluster expand must return seeds unchanged, got %v", got)
+	}
+
+	registry.update([]string{"b:2", "c:3", "e:5"})
+	got = registry.expand([]string{"a:1"})
+	want := []string{"a:1", "b:2"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("multi-cluster update must not merge clusters, want %v, got %v", want, got)
+	}
+}
+
+func TestValidUniqueHostPortsFiltersInvalidAndDeduplicates(t *testing.T) {
+	got := validUniqueHostPorts([]string{
+		"a:1",
+		"a:1",
+		"missing-port",
+		"b:0",
+		"b:65536",
+		":6041",
+		"[::1]:6041",
+		"c:6041",
+	})
+	want := []string{"a:1", "[::1]:6041", "c:6041"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestClusterRegistryConcurrentUpdateConvergesWithoutDuplicates(t *testing.T) {
+	registry := newClusterRegistry()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			registry.update([]string{"seed:6041", "peer:6041"})
+		}()
+	}
+	wg.Wait()
+
+	got := registry.expand([]string{"seed:6041"})
+	want := []string{"seed:6041", "peer:6041"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}

--- a/ws/unified/config.go
+++ b/ws/unified/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	AutoReconnect       bool
 	ReconnectIntervalMs int
 	ReconnectRetryCount int
+	AdapterHA           bool
 
 	// Backward compatibility fields (deprecated, use Endpoints instead)
 	// These are only used during DSN parsing and converted to Endpoints

--- a/ws/unified/conn.go
+++ b/ws/unified/conn.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -56,7 +57,7 @@ func (c *Client) Connect() error {
 }
 
 // defaultBootstrap performs the normal connect handshake on a new websocket connection.
-func (c *Client) defaultBootstrap(conn *websocket.Conn) error {
+func (c *Client) defaultBootstrap(conn *websocket.Conn, endpointURL string) error {
 	// Keep legacy behavior: fail fast when server version is incompatible.
 	if err := tdversion.WSCheckVersion(conn); err != nil {
 		return err
@@ -67,15 +68,16 @@ func (c *Client) defaultBootstrap(conn *websocket.Conn) error {
 		tz = c.config.Timezone.String()
 	}
 	req := &proto.WSConnectReq{
-		ReqID:       uint64(common.GetReqID()),
-		User:        c.config.User,
-		Password:    c.config.Passwd,
-		DB:          c.config.DbName,
-		TZ:          tz,
-		TOTPCode:    c.config.TotpCode,
-		BearerToken: c.config.BearerToken,
-		App:         common.GetProcessName(),
-		Connector:   common.GetConnectorInfo("ws"),
+		ReqID:         uint64(common.GetReqID()),
+		User:          c.config.User,
+		Password:      c.config.Passwd,
+		DB:            c.config.DbName,
+		TZ:            tz,
+		TOTPCode:      c.config.TotpCode,
+		BearerToken:   c.config.BearerToken,
+		App:           common.GetProcessName(),
+		Connector:     common.GetConnectorInfo("ws"),
+		ListInstances: c.config.AdapterHA && atomic.LoadUint32(&c.instancesFetched) == 0,
 	}
 
 	args, err := client.JsonI.Marshal(req)
@@ -114,7 +116,11 @@ func (c *Client) defaultBootstrap(conn *websocket.Conn) error {
 	}
 
 	var resp proto.WSConnectResp
-	return decodeAndCheckJSONResponse(respBytes, &resp)
+	if err = decodeAndCheckJSONResponse(respBytes, &resp); err != nil {
+		return err
+	}
+	c.mergeAdapterHAInstancesOnce(&c.instancesFetched, endpointURL, &resp.ListInstances)
+	return nil
 }
 
 // handleTextMessage routes incoming text messages to pending requests by req_id.

--- a/ws/unified/conn_bootstrap_test.go
+++ b/ws/unified/conn_bootstrap_test.go
@@ -92,6 +92,90 @@ func TestDefaultBootstrapSendsTimezone(t *testing.T) {
 	}
 }
 
+func TestDefaultBootstrapAdapterHARequestsInstancesOnlyOnce(t *testing.T) {
+	withFreshClusterRegistry(t)
+	listInstancesCh := make(chan bool, 2)
+	errCh := make(chan error, 2)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := queryLifecycleUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		for {
+			_, msg, readErr := conn.ReadMessage()
+			if readErr != nil {
+				errCh <- readErr
+				return
+			}
+			if isVersionActionText(string(msg)) {
+				if writeErr := writeVersionResponse(conn); writeErr != nil {
+					errCh <- writeErr
+					return
+				}
+				continue
+			}
+			var action client.WSAction
+			if err = json.Unmarshal(msg, &action); err != nil {
+				errCh <- err
+				return
+			}
+			if strings.ToLower(action.Action) != "conn" {
+				continue
+			}
+			var req proto.WSConnectReq
+			if err = json.Unmarshal(action.Args, &req); err != nil {
+				errCh <- err
+				return
+			}
+			listInstancesCh <- req.ListInstances
+			err = conn.WriteMessage(websocket.TextMessage, []byte(`{"code":0,"message":"","action":"conn","req_id":0,"list_instances":["peer:6041"]}`))
+			if err != nil {
+				errCh <- err
+			}
+			return
+		}
+	}))
+	defer s.Close()
+
+	cfg := NewConfig([]string{wsEndpointFromHTTP(s.URL)})
+	cfg.User = "root"
+	cfg.Passwd = "taosdata"
+	cfg.AdapterHA = true
+	cfg.ReadTimeout = time.Second
+	cfg.WriteTimeout = time.Second
+
+	c, err := NewClient(cfg, "/ws")
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.Connect())
+	select {
+	case got := <-listInstancesCh:
+		assert.True(t, got, "first successful connect should request list_instances")
+	case err = <-errCh:
+		t.Fatalf("bootstrap server failed: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for first bootstrap request")
+	}
+	require.Len(t, c.failover.endpointsCopy(), 2)
+
+	require.NoError(t, c.reconnectWithBootstrap(c.defaultBootstrap, nil))
+	select {
+	case got := <-listInstancesCh:
+		assert.False(t, got, "reconnect should not request list_instances")
+	case err = <-errCh:
+		t.Fatalf("bootstrap server failed: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for second bootstrap request")
+	}
+}
+
 // TestClientPingSendsPingFrame verifies the expected behavior for this scenario.
 func TestClientPingSendsPingFrame(t *testing.T) {
 	var pingSeen uint32

--- a/ws/unified/dsn.go
+++ b/ws/unified/dsn.go
@@ -181,6 +181,7 @@ func NewConfigFromDSN(dsn string, defaultPath string) (*Config, error) {
 	cfg.TotpCode = parsed.TotpCode
 	cfg.BearerToken = parsed.BearerToken
 	cfg.AutoReconnect = parsed.AutoReconnect
+	cfg.AdapterHA = parsed.AdapterHA
 	cfg.SkipVerify = parsed.SkipVerify
 	if parsed.ChanLength != 0 {
 		cfg.ChanLength = parsed.ChanLength
@@ -254,6 +255,12 @@ func parseDSNParams(cfg *Config, params string) error {
 				return newInvalidDSNErrorf("invalid autoReconnect value: %s", value)
 			}
 			cfg.AutoReconnect = parsed
+		case "adapterHa":
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return newInvalidDSNErrorf("invalid adapterHa value: %s", value)
+			}
+			cfg.AdapterHA = parsed
 		case "skipVerify":
 			parsed, err := strconv.ParseBool(value)
 			if err != nil {

--- a/ws/unified/dsn_boundary_test.go
+++ b/ws/unified/dsn_boundary_test.go
@@ -13,7 +13,7 @@ func TestParseDSNParamsAllKnownKeys(t *testing.T) {
 	cfg := &Config{
 		InterpolateParams: true,
 	}
-	err := parseDSNParams(cfg, "flagOnly&interpolateParams=false&token=tk1&enableCompression=true&readTimeout=1s&writeTimeout=2s&timezone=Asia%2FShanghai&bearerToken=b1&totpCode=123456&autoReconnect=true&chanLength=8&reconnectIntervalMs=5000&reconnectRetryCount=10&custom=a%2Bb")
+	err := parseDSNParams(cfg, "flagOnly&interpolateParams=false&token=tk1&enableCompression=true&readTimeout=1s&writeTimeout=2s&timezone=Asia%2FShanghai&bearerToken=b1&totpCode=123456&autoReconnect=true&adapterHa=true&chanLength=8&reconnectIntervalMs=5000&reconnectRetryCount=10&custom=a%2Bb")
 	require.NoError(t, err)
 
 	assert.False(t, cfg.InterpolateParams)
@@ -26,6 +26,7 @@ func TestParseDSNParamsAllKnownKeys(t *testing.T) {
 	assert.Equal(t, "b1", cfg.BearerToken)
 	assert.Equal(t, "123456", cfg.TotpCode)
 	assert.True(t, cfg.AutoReconnect)
+	assert.True(t, cfg.AdapterHA)
 	assert.Equal(t, uint(8), cfg.ChanLength)
 	assert.Equal(t, 5000, cfg.ReconnectIntervalMs)
 	assert.Equal(t, 10, cfg.ReconnectRetryCount)
@@ -79,6 +80,11 @@ func TestParseDSNParamsErrorBranches(t *testing.T) {
 			name:       "invalid autoReconnect",
 			rawParams:  "autoReconnect=abc",
 			wantErrMsg: "invalid autoReconnect value",
+		},
+		{
+			name:       "invalid adapterHa",
+			rawParams:  "adapterHa=abc",
+			wantErrMsg: "invalid adapterHa value",
 		},
 		{
 			name:       "invalid chanLength",
@@ -204,6 +210,7 @@ func TestNewConfigFromDSNAllFields(t *testing.T) {
 		"bearerToken=bear1&" +
 		"totpCode=654321&" +
 		"autoReconnect=true&" +
+		"adapterHa=true&" +
 		"chanLength=16&" +
 		"reconnectIntervalMs=3000&" +
 		"reconnectRetryCount=5&" +
@@ -238,6 +245,7 @@ func TestNewConfigFromDSNAllFields(t *testing.T) {
 
 	// runtime fields
 	assert.True(t, cfg.AutoReconnect)
+	assert.True(t, cfg.AdapterHA)
 	assert.Equal(t, uint(16), cfg.ChanLength)
 	assert.Equal(t, 3000, cfg.ReconnectIntervalMs)
 	assert.Equal(t, 5, cfg.ReconnectRetryCount)
@@ -253,6 +261,7 @@ func TestNewConfigFromDSNRuntimeDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, cfg.AutoReconnect)
+	assert.False(t, cfg.AdapterHA)
 	assert.Equal(t, uint(1), cfg.ChanLength)
 	assert.Equal(t, 2000, cfg.ReconnectIntervalMs)
 	assert.Equal(t, 3, cfg.ReconnectRetryCount)

--- a/ws/unified/failover.go
+++ b/ws/unified/failover.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	tLog "github.com/taosdata/driver-go/v3/log"
 )
 
 type endpointCandidate struct {
@@ -144,6 +146,34 @@ func (s *failoverState) endpointsCopy() []string {
 	return out
 }
 
+func (s *failoverState) mergeEndpoints(newEndpoints []string) int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	seen := make(map[string]struct{}, len(s.endpointHostPorts)+len(newEndpoints))
+	for i := 0; i < len(s.endpointHostPorts); i++ {
+		seen[s.endpointHostPorts[i]] = struct{}{}
+	}
+
+	added := 0
+	for i := 0; i < len(newEndpoints); i++ {
+		endpoint := newEndpoints[i]
+		hostPort, err := endpointHostPortKey(endpoint)
+		if err != nil {
+			tLog.Warnf(0, "adapter HA: invalid discovered endpoint ignored: %s", endpoint)
+			continue
+		}
+		if _, ok := seen[hostPort]; ok {
+			continue
+		}
+		seen[hostPort] = struct{}{}
+		s.endpoints = append(s.endpoints, endpoint)
+		s.endpointHostPorts = append(s.endpointHostPorts, hostPort)
+		added++
+	}
+	return added
+}
+
 // active returns the currently selected endpoint candidate.
 func (s *failoverState) active() endpointCandidate {
 	s.lock.RLock()
@@ -231,6 +261,68 @@ func (s *failoverState) reconnectCandidates() []endpointCandidate {
 		})
 	}
 	return candidates
+}
+
+func hostPortsOf(endpoints []string) []string {
+	hostPorts := make([]string, 0, len(endpoints))
+	for i := 0; i < len(endpoints); i++ {
+		hostPort, err := endpointHostPortKey(endpoints[i])
+		if err != nil {
+			tLog.Warnf(0, "adapter HA: invalid endpoint ignored while collecting host:port: %s", endpoints[i])
+			continue
+		}
+		hostPorts = append(hostPorts, hostPort)
+	}
+	return validUniqueHostPorts(hostPorts)
+}
+
+func formatHostPortsToURLs(hostPorts []string, templateEndpoint string) []string {
+	tmpl, err := url.Parse(templateEndpoint)
+	if err != nil || tmpl.Scheme == "" || tmpl.Host == "" {
+		tLog.Warnf(0, "adapter HA: invalid template endpoint: %s", templateEndpoint)
+		return nil
+	}
+	// Adapter discovery returns only host:port. Discovered endpoints therefore
+	// inherit the connected template URL's scheme, path, and query/token contract.
+	// Mixed ws/wss, path, or auth-token layouts need server-side full URL metadata.
+	out := make([]string, 0, len(hostPorts))
+	for i := 0; i < len(hostPorts); i++ {
+		hostPort := hostPorts[i]
+		if !isValidHostPort(hostPort) {
+			tLog.Warnf(0, "adapter HA: invalid host:port ignored while formatting endpoint: %s", hostPort)
+			continue
+		}
+		u := *tmpl
+		u.Host = hostPort
+		out = append(out, u.String())
+	}
+	return out
+}
+
+func mergeURLList(existing []string, additional []string) []string {
+	out := append([]string(nil), existing...)
+	seen := make(map[string]struct{}, len(existing)+len(additional))
+	for i := 0; i < len(existing); i++ {
+		hostPort, err := endpointHostPortKey(existing[i])
+		if err != nil {
+			continue
+		}
+		seen[hostPort] = struct{}{}
+	}
+	for i := 0; i < len(additional); i++ {
+		endpoint := additional[i]
+		hostPort, err := endpointHostPortKey(endpoint)
+		if err != nil {
+			tLog.Warnf(0, "adapter HA: invalid endpoint ignored while merging URL list: %s", endpoint)
+			continue
+		}
+		if _, ok := seen[hostPort]; ok {
+			continue
+		}
+		seen[hostPort] = struct{}{}
+		out = append(out, endpoint)
+	}
+	return out
 }
 
 // leastConnectionCandidatesLocked returns all endpoints sorted by host:port connection count.

--- a/ws/unified/failover_test.go
+++ b/ws/unified/failover_test.go
@@ -166,3 +166,56 @@ func TestFailoverStateMarkActiveInvalidIndex(t *testing.T) {
 		t.Fatal("expect invalid endpoint index error")
 	}
 }
+
+// TestFailoverStateMergeEndpointsAppendsNewHostPorts verifies dynamic endpoint
+// discovery keeps existing indexes stable and only appends new host:port values.
+func TestFailoverStateMergeEndpointsAppendsNewHostPorts(t *testing.T) {
+	state, err := newFailoverState([]string{"ws://a:1/ws?token=seed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	added := state.mergeEndpoints([]string{
+		"ws://a:1/other?token=dup",
+		"wss://b:2/rest/tmq?token=next",
+		"not-a-url",
+	})
+
+	if added != 1 {
+		t.Fatalf("want one added endpoint, got %d", added)
+	}
+	got := state.endpointsCopy()
+	want := []string{"ws://a:1/ws?token=seed", "wss://b:2/rest/tmq?token=next"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want endpoints %v, got %v", want, got)
+	}
+	hostPort0, err := state.hostPortByIndex(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostPort1, err := state.hostPortByIndex(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hostPort0 != "a:1" || hostPort1 != "b:2" {
+		t.Fatalf("unexpected host ports: %s, %s", hostPort0, hostPort1)
+	}
+}
+
+func TestFormatHostPortsToURLsPreservesTemplate(t *testing.T) {
+	got := formatHostPortsToURLs([]string{"b:2", "[::1]:6041"}, "wss://a:1/rest/tmq?token=abc&x=1")
+	want := []string{
+		"wss://b:2/rest/tmq?token=abc&x=1",
+		"wss://[::1]:6041/rest/tmq?token=abc&x=1",
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}
+
+func TestHostPortsOfEndpointsUsesEndpointDefaults(t *testing.T) {
+	got := hostPortsOf([]string{"ws://a:1/ws", "wss://b/ws", "ws://[::1]:6041/ws", "bad"})
+	want := []string{"a:1", "b:443", "[::1]:6041"}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}

--- a/ws/unified/open_integration_test.go
+++ b/ws/unified/open_integration_test.go
@@ -1,11 +1,16 @@
 package unified
 
 import (
+	"database/sql/driver"
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	taosErrors "github.com/taosdata/driver-go/v3/errors"
 )
 
@@ -76,4 +81,35 @@ func TestUnifiedExecIllegalSQLReturnsTaosError(t *testing.T) {
 	if errors.As(err, &unifiedErr) {
 		t.Fatalf("expected non-unified error for illegal SQL, got unified error: %+v", unifiedErr)
 	}
+}
+
+func TestQueryWithAdapterHA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+	withFreshClusterRegistry(t)
+
+	cfg, err := NewConfigFromDSN("root:taosdata@ws(127.0.0.1:6041)/?adapterHa=true", defaultDSNPath)
+	require.NoError(t, err)
+	require.True(t, cfg.AdapterHA)
+
+	client, err := NewClient(cfg, defaultDSNPath)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	require.Equal(t, uint32(0), atomic.LoadUint32(&client.instancesFetched))
+	err = client.Connect()
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), atomic.LoadUint32(&client.instancesFetched))
+	require.NotEmpty(t, client.failover.endpointsCopy())
+
+	rows, err := client.Query(0, "select 42")
+	require.NoError(t, err)
+	require.NotNil(t, rows)
+	t.Cleanup(func() { _ = rows.Close() })
+
+	values := make([]driver.Value, 1)
+	require.NoError(t, rows.Next(values))
+	require.Equal(t, "42", fmt.Sprint(values[0]))
+	require.ErrorIs(t, rows.Next(values), io.EOF)
 }

--- a/ws/unified/proto/proto_test.go
+++ b/ws/unified/proto/proto_test.go
@@ -266,3 +266,40 @@ func TestBaseRespWithErrorCode(t *testing.T) {
 	assert.Equal(t, "Database not exist", resp.GetMessage())
 	assert.Equal(t, uint64(5), resp.GetReqID())
 }
+
+func TestWSConnectListInstancesJSON(t *testing.T) {
+	withoutList, err := json.Marshal(&WSConnectReq{ReqID: 1})
+	assert.NoError(t, err)
+	assert.NotContains(t, string(withoutList), "list_instances")
+
+	withList, err := json.Marshal(&WSConnectReq{ReqID: 1, ListInstances: true})
+	assert.NoError(t, err)
+	assert.Contains(t, string(withList), `"list_instances":true`)
+
+	var missing WSConnectResp
+	err = json.Unmarshal([]byte(`{"code":0,"message":"","action":"conn","req_id":1}`), &missing)
+	assert.NoError(t, err)
+	assert.Nil(t, missing.ListInstances)
+
+	var empty WSConnectResp
+	err = json.Unmarshal([]byte(`{"code":0,"message":"","action":"conn","req_id":1,"list_instances":[]}`), &empty)
+	assert.NoError(t, err)
+	if assert.NotNil(t, empty.ListInstances) {
+		assert.Empty(t, empty.ListInstances)
+	}
+}
+
+func TestSubscribeListInstancesJSON(t *testing.T) {
+	withoutList, err := json.Marshal(&SubscribeReq{ReqID: 2})
+	assert.NoError(t, err)
+	assert.NotContains(t, string(withoutList), "list_instances")
+
+	withList, err := json.Marshal(&SubscribeReq{ReqID: 2, ListInstances: true})
+	assert.NoError(t, err)
+	assert.Contains(t, string(withList), `"list_instances":true`)
+
+	var resp SubscribeResp
+	err = json.Unmarshal([]byte(`{"code":0,"message":"","action":"subscribe","req_id":2,"list_instances":["a:1"]}`), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a:1"}, resp.ListInstances)
+}

--- a/ws/unified/proto/query.go
+++ b/ws/unified/proto/query.go
@@ -34,19 +34,21 @@ func (b *BaseResp) GetReqID() uint64 {
 }
 
 type WSConnectReq struct {
-	ReqID       uint64 `json:"req_id"`
-	User        string `json:"user"`
-	Password    string `json:"password"`
-	DB          string `json:"db"`
-	TZ          string `json:"tz"`
-	App         string `json:"app"`
-	Connector   string `json:"connector"`
-	TOTPCode    string `json:"totp_code"`
-	BearerToken string `json:"bearer_token"`
+	ReqID         uint64 `json:"req_id"`
+	User          string `json:"user"`
+	Password      string `json:"password"`
+	DB            string `json:"db"`
+	TZ            string `json:"tz"`
+	App           string `json:"app"`
+	Connector     string `json:"connector"`
+	TOTPCode      string `json:"totp_code"`
+	BearerToken   string `json:"bearer_token"`
+	ListInstances bool   `json:"list_instances,omitempty"`
 }
 
 type WSConnectResp struct {
 	BaseResp
+	ListInstances []string `json:"list_instances,omitempty"`
 }
 
 type WSQueryReq struct {

--- a/ws/unified/proto/tmq.go
+++ b/ws/unified/proto/tmq.go
@@ -24,10 +24,12 @@ type SubscribeReq struct {
 	App                  string            `json:"app"`
 	Connector            string            `json:"connector"`
 	Config               map[string]string `json:"config"`
+	ListInstances        bool              `json:"list_instances,omitempty"`
 }
 
 type SubscribeResp struct {
 	BaseResp
+	ListInstances []string `json:"list_instances,omitempty"`
 }
 
 type PollReq struct {

--- a/ws/unified/tmq_config.go
+++ b/ws/unified/tmq_config.go
@@ -25,6 +25,7 @@ type config struct {
 	EnableCompression    bool
 	SkipVerify           bool
 	AutoReconnect        bool
+	AdapterHA            bool
 	ReconnectIntervalMs  int
 	ReconnectRetryCount  int
 	SessionTimeoutMS     string
@@ -115,6 +116,10 @@ func (c *config) setSkipVerify(skipVerify bool) {
 
 func (c *config) setAutoReconnect(autoReconnect bool) {
 	c.AutoReconnect = autoReconnect
+}
+
+func (c *config) setAdapterHA(adapterHA bool) {
+	c.AdapterHA = adapterHA
 }
 
 func (c *config) setReconnectIntervalMs(reconnectIntervalMs int) {

--- a/ws/unified/tmq_config_validation_test.go
+++ b/ws/unified/tmq_config_validation_test.go
@@ -207,6 +207,16 @@ func TestTMQConfigMapToConfigWrong(t *testing.T) {
 			wantErr: "ws.autoReconnect expects type bool, not int",
 		},
 		{
+			name: "ws.adapterHa",
+			args: args{
+				m: commontmq.ConfigMap{
+					"ws.url":       "ws://127.0.0.1:6041",
+					"ws.adapterHa": 123,
+				},
+			},
+			wantErr: "ws.adapterHa expects type bool, not int",
+		},
+		{
 			name: "ws.reconnectIntervalMs",
 			args: args{
 				m: commontmq.ConfigMap{
@@ -278,5 +288,18 @@ func TestTMQConfigMapToConfigSkipVerify(t *testing.T) {
 	assert.NoError(t, err)
 	if assert.NotNil(t, cfg) {
 		assert.True(t, cfg.SkipVerify)
+	}
+}
+
+func TestTMQConfigMapToConfigAdapterHA(t *testing.T) {
+	cfg, err := configMapToConfig(commontmq.ConfigMap{
+		"ws.url":       "ws://127.0.0.1:6041",
+		"ws.adapterHa": true,
+	})
+	assert.NoError(t, err)
+	if assert.NotNil(t, cfg) {
+		assert.True(t, cfg.AdapterHA)
+		_, exists := cfg.OtherOptions["ws.adapterHa"]
+		assert.False(t, exists)
 	}
 }

--- a/ws/unified/tmq_consumer.go
+++ b/ws/unified/tmq_consumer.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -45,6 +46,7 @@ type TMQConsumer struct {
 	closeOnce          sync.Once
 	topics             []string
 	autoReconnect      bool
+	instancesFetched   uint32
 	lastMessageID      uint64
 }
 
@@ -93,6 +95,7 @@ func NewTMQConsumer(conf *tmq.ConfigMap) (*TMQConsumer, error) {
 	unifiedCfg.EnableCompression = config.EnableCompression
 	unifiedCfg.SkipVerify = config.SkipVerify
 	unifiedCfg.AutoReconnect = config.AutoReconnect
+	unifiedCfg.AdapterHA = config.AdapterHA
 	unifiedCfg.ReconnectIntervalMs = config.ReconnectIntervalMs
 	unifiedCfg.ReconnectRetryCount = config.ReconnectRetryCount
 
@@ -127,7 +130,7 @@ func NewTMQConsumer(conf *tmq.ConfigMap) (*TMQConsumer, error) {
 	return consumer, nil
 }
 
-func (c *TMQConsumer) bootstrapTMQ(conn *websocket.Conn) error {
+func (c *TMQConsumer) bootstrapTMQ(conn *websocket.Conn, endpointURL string) error {
 	return tdversion.WSCheckVersion(conn)
 }
 
@@ -182,6 +185,7 @@ var excludeConfig = map[string]struct{}{
 	"ws.message.enableCompression": {},
 	"ws.skipVerify":                {},
 	"ws.autoReconnect":             {},
+	"ws.adapterHa":                 {},
 	"ws.reconnectIntervalMs":       {},
 	"ws.reconnectRetryCount":       {},
 	"session.timeout.ms":           {},
@@ -262,6 +266,10 @@ func configMapToConfig(m tmq.ConfigMap) (*config, error) {
 	if err != nil {
 		return nil, err
 	}
+	adapterHA, err := m.Get("ws.adapterHa", false)
+	if err != nil {
+		return nil, err
+	}
 	reconnectIntervalMs, err := m.Get("ws.reconnectIntervalMs", int(2000))
 	if err != nil {
 		return nil, err
@@ -304,6 +312,7 @@ func configMapToConfig(m tmq.ConfigMap) (*config, error) {
 	config.setEnableCompression(enableCompression.(bool))
 	config.setSkipVerify(skipVerify.(bool))
 	config.setAutoReconnect(autoReconnect.(bool))
+	config.setAdapterHA(adapterHA.(bool))
 	config.setReconnectIntervalMs(reconnectIntervalMs.(int))
 	config.setReconnectRetryCount(reconnectRetryCount.(int))
 	config.setSessionTimeoutMS(sessionTimeoutMS.(string))
@@ -554,11 +563,13 @@ func (c *TMQConsumer) doSubscribe(topics []string, reconnect bool) error {
 		App:               common.GetProcessName(),
 		Connector:         common.GetConnectorInfo("ws"),
 		Config:            c.otherOptions,
+		ListInstances:     c.client.config.AdapterHA && atomic.LoadUint32(&c.instancesFetched) == 0,
 	}
 	var resp proto.SubscribeResp
 	if err := c.sendTextActionAndDecode(reqID, proto.TMQActionSubscribe, req, reconnect, nil, &resp); err != nil {
 		return err
 	}
+	c.client.mergeAdapterHAInstancesOnce(&c.instancesFetched, c.client.activeEndpointURL(), &resp.ListInstances)
 	c.setTopics(topics)
 	return nil
 }

--- a/ws/unified/tmq_integration_test.go
+++ b/ws/unified/tmq_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -206,4 +207,66 @@ func TestTMQConsumerRealAdapterCommitAndErrorBranches(t *testing.T) {
 	te, ok := event.(commontmq.Error)
 	require.True(t, ok, "poll should return tmq.Error when consumer has stored err")
 	require.Equal(t, commontmq.ErrorOther, te.Code())
+}
+
+func TestTMQConsumerWithAdapterHA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+	withFreshClusterRegistry(t)
+
+	tmqIntegrationSQL(t, "select 1")
+	tmqIntegrationSQL(t, "drop topic if exists topic_1783329045")
+	tmqIntegrationSQL(t, "drop database if exists test_1783329045")
+	tmqIntegrationSQL(t, "create database test_1783329045")
+	tmqIntegrationSQL(t, "create table test_1783329045.t (ts timestamp, v int)")
+	tmqIntegrationSQL(t, "insert into test_1783329045.t values(now, 7)")
+	tmqIntegrationSQL(t, "create topic topic_1783329045 as select * from test_1783329045.t")
+	t.Cleanup(func() {
+		tmqIntegrationSQL(t, "drop topic if exists topic_1783329045")
+		tmqIntegrationSQL(t, "drop database if exists test_1783329045")
+	})
+
+	cfg := commontmq.ConfigMap{
+		"ws.url":              "ws://127.0.0.1:6041",
+		"ws.adapterHa":        true,
+		"td.connect.user":     "root",
+		"td.connect.pass":     "taosdata",
+		"group.id":            "g23832",
+		"client.id":           "c23832",
+		"auto.offset.reset":   "earliest",
+		"enable.auto.commit":  "false",
+		"msg.with.table.name": "true",
+		"ws.autoReconnect":    true,
+	}
+	consumer, err := NewTMQConsumer(&cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = consumer.Unsubscribe()
+		_ = consumer.Close()
+	})
+
+	require.Equal(t, uint32(0), atomic.LoadUint32(&consumer.instancesFetched))
+	require.NoError(t, consumer.Subscribe("topic_1783329045", nil))
+	require.Equal(t, uint32(1), atomic.LoadUint32(&consumer.instancesFetched))
+	require.Contains(t, consumer.client.failover.endpointsCopy(), "ws://127.0.0.1:6041/rest/tmq")
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		event := consumer.Poll(500)
+		if event == nil {
+			continue
+		}
+		if te, ok := event.(commontmq.Error); ok {
+			t.Fatalf("unexpected tmq error event: %v", te)
+		}
+		if msg, ok := event.(*commontmq.DataMessage); ok {
+			require.Equal(t, "test_1783329045", msg.DBName())
+			require.Equal(t, "topic_1783329045", msg.Topic())
+			require.Equal(t, uint32(1), atomic.LoadUint32(&consumer.instancesFetched))
+			require.NotEmpty(t, consumer.client.failover.endpointsCopy())
+			return
+		}
+	}
+	t.Fatal("did not receive data message from adapterHa real taosadapter")
 }

--- a/ws/unified/tmq_test.go
+++ b/ws/unified/tmq_test.go
@@ -1,10 +1,20 @@
 package unified
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commontmq "github.com/taosdata/driver-go/v3/common/tmq"
+	"github.com/taosdata/driver-go/v3/ws/client"
+	"github.com/taosdata/driver-go/v3/ws/unified/proto"
 )
 
 // TestNewTMQConsumerNilConfig verifies the expected behavior for this scenario.
@@ -51,6 +61,88 @@ func TestTMQConfigMapParsesMultipleEndpoints(t *testing.T) {
 		"ws://127.0.0.1:6042/rest/tmq",
 	}, cfg.Endpoints)
 	require.Equal(t, "ws://127.0.0.1:6041/rest/tmq", cfg.Url)
+}
+
+func TestTMQSubscribeAdapterHARequestsInstancesOnlyOnce(t *testing.T) {
+	withFreshClusterRegistry(t)
+	listInstancesCh := make(chan bool, 2)
+	errCh := make(chan error, 2)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := queryLifecycleUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		for {
+			_, msg, readErr := conn.ReadMessage()
+			if readErr != nil {
+				return
+			}
+			if isVersionActionText(string(msg)) {
+				if writeErr := writeVersionResponse(conn); writeErr != nil {
+					errCh <- writeErr
+					return
+				}
+				continue
+			}
+			var action client.WSAction
+			if err = json.Unmarshal(msg, &action); err != nil {
+				errCh <- err
+				return
+			}
+			if strings.ToLower(action.Action) != proto.TMQActionSubscribe {
+				continue
+			}
+			var req proto.SubscribeReq
+			if err = json.Unmarshal(action.Args, &req); err != nil {
+				errCh <- err
+				return
+			}
+			listInstancesCh <- req.ListInstances
+			resp := []byte(`{"code":0,"message":"","action":"subscribe","req_id":` + strconv.FormatUint(req.ReqID, 10) + `,"list_instances":["peer:6041"]}`)
+			if writeErr := conn.WriteMessage(websocket.TextMessage, resp); writeErr != nil {
+				errCh <- writeErr
+				return
+			}
+		}
+	}))
+	defer s.Close()
+
+	cfg := commontmq.ConfigMap{
+		"ws.url":       wsEndpointFromHTTP(s.URL),
+		"ws.adapterHa": true,
+	}
+	consumer, err := NewTMQConsumer(&cfg)
+	require.NoError(t, err)
+	defer func() {
+		_ = consumer.Close()
+	}()
+
+	require.NoError(t, consumer.Subscribe("topic_a", nil))
+	select {
+	case got := <-listInstancesCh:
+		assert.True(t, got, "first subscribe should request list_instances")
+	case err = <-errCh:
+		t.Fatalf("tmq server failed: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for first subscribe")
+	}
+	require.Len(t, consumer.client.failover.endpointsCopy(), 2)
+
+	require.NoError(t, consumer.Subscribe("topic_b", nil))
+	select {
+	case got := <-listInstancesCh:
+		assert.False(t, got, "second subscribe should not request list_instances")
+	case err = <-errCh:
+		t.Fatalf("tmq server failed: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for second subscribe")
+	}
 }
 
 // TestBuildTMQTimeoutMessageRedactsSensitiveArgs verifies timeout message keeps context while masking secrets.


### PR DESCRIPTION
# Description

Sync the latest changes from the TDengine TSDB subtree source/taos-connector-go back to driver-go.

This PR preserves the original commit authors/messages for the two subtree commits that were not already present in driver-go/main:

- feat(vst): virtual super table inheritance (BASE ON) (rd-public/tsdb!835)
- feat(go): support adapter ha (rd-public/tsdb!1065)

The resulting driver-go tree matches TDengine TSDB HEAD:source/taos-connector-go exactly.

# Verification

- git tree comparison: TDengine TSDB HEAD:source/taos-connector-go == this branch HEAD^{tree}
- CGO_ENABLED=0 go test ./common/tmq
- CGO_ENABLED=0 go test ./ws/unified/proto
- CGO_ENABLED=0 go test ./ws/unified -run '<targeted unit tests for adapter HA, registry, failover, bootstrap, TMQ config>'

Full go test ./... was also attempted, but this local environment is missing taos.h and a running local taosadapter/taosd on 127.0.0.1:6041, so integration/CGO-dependent packages fail for environmental reasons.